### PR TITLE
Add MSTORE8 support in MemoryGadget

### DIFF
--- a/bus-mapping/src/evm.rs
+++ b/bus-mapping/src/evm.rs
@@ -268,6 +268,8 @@ impl GasCost {
     pub const SLOW: Self = Self(10);
     /// Constant cost for ext step
     pub const EXT: Self = Self(20);
+    /// Constant cost for every additional word when expanding memory
+    pub const MEMORY: Self = Self(3);
     /// Constant cost for a cold SLOAD
     pub const COLD_SLOAD_COST: Self = Self(2100);
     /// Constant cost for a cold account access

--- a/bus-mapping/src/evm/gas.rs
+++ b/bus-mapping/src/evm/gas.rs
@@ -16,10 +16,12 @@ impl GasCost {
     pub const SLOW: Self = Self(10);
     /// Constant cost for ext step
     pub const EXT: Self = Self(20);
+    /// Constant cost for every additional word when expanding memory
+    pub const MEMORY: Self = Self(3);
     /// Constant cost for a cold SLOAD
     pub const COLD_SLOAD_COST: Self = Self(2100);
     /// Constant cost for a cold account access
-    pub const COLD_ACCOUNT_ACCESS_COST: Self = Self(100);
+    pub const COLD_ACCOUNT_ACCESS_COST: Self = Self(2600);
     /// Constant cost for a warm storage read
     pub const WARM_STORAGE_READ_COST: Self = Self(100);
 }

--- a/zkevm-circuits/src/evm_circuit.rs
+++ b/zkevm-circuits/src/evm_circuit.rs
@@ -98,6 +98,7 @@ pub(crate) enum BusMappingLookup<F> {
         call_id: Expression<F>,
         index: Expression<F>,
         value: Expression<F>,
+        gc_offset: Expression<F>,
     },
     AccountStorage {
         is_write: bool,
@@ -564,16 +565,15 @@ impl<F: FieldExt> EvmCircuit<F> {
                                 .push(vec![0.expr(); 7].try_into().unwrap());
                         }
 
-                        let mut exprs = vec![
-                            global_counter.expr() + rw_lookup_count.expr(),
-                            rw_lookup.rw_target().expr(),
-                        ];
-                        exprs.extend(match rw_lookup {
+                        let rw_target = rw_lookup.rw_target().expr();
+                        let exprs = vec![match rw_lookup {
                             BusMappingLookup::Stack {
                                 is_write,
                                 index_offset,
                                 value,
                             } => [
+                                global_counter.expr() + rw_lookup_count.expr(),
+                                rw_target,
                                 is_write,
                                 call_id.expr(),
                                 stack_pointer.expr() + index_offset,
@@ -585,7 +585,16 @@ impl<F: FieldExt> EvmCircuit<F> {
                                 call_id,
                                 index,
                                 value,
-                            } => [is_write, call_id, index, value, 0.expr()],
+                                gc_offset,
+                            } => [
+                                global_counter.expr() + gc_offset,
+                                rw_target,
+                                is_write,
+                                call_id,
+                                index,
+                                value,
+                                0.expr(),
+                            ],
                             BusMappingLookup::AccountStorage {
                                 is_write,
                                 address,
@@ -593,6 +602,8 @@ impl<F: FieldExt> EvmCircuit<F> {
                                 value,
                                 value_prev,
                             } => [
+                                global_counter.expr() + rw_lookup_count.expr(),
+                                rw_target,
                                 is_write.expr(),
                                 address,
                                 location,
@@ -601,7 +612,8 @@ impl<F: FieldExt> EvmCircuit<F> {
                             ],
                             // TODO:
                             _ => unimplemented!(),
-                        });
+                        }]
+                        .concat();
 
                         for (acc, expr) in
                             rw_lookups[rw_lookup_count].iter_mut().zip(exprs)

--- a/zkevm-circuits/src/evm_circuit/op_execution.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution.rs
@@ -624,9 +624,17 @@ impl<F: FieldExt> OpExecutionGadget<F> {
                 (_, _, _, OpcodeId::SIGNEXTEND) => self
                     .signextend_gadget
                     .assign(region, offset, core_state, execution_step)?,
-                (_, _, _, OpcodeId::MLOAD | OpcodeId::MSTORE) => self
-                    .memory_gadget
-                    .assign(region, offset, core_state, execution_step)?,
+                (
+                    _,
+                    _,
+                    _,
+                    OpcodeId::MLOAD | OpcodeId::MSTORE | OpcodeId::MSTORE8,
+                ) => self.memory_gadget.assign(
+                    region,
+                    offset,
+                    core_state,
+                    execution_step,
+                )?,
                 _ => unimplemented!(),
             }
         }

--- a/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/arithmetic.rs
@@ -100,6 +100,7 @@ impl<F: FieldExt> OpGadget<F> for AddGadget<F> {
                     - (state_curr.stack_pointer.expr() + 1.expr()),
                 state_next.gas_counter.expr()
                     - (state_curr.gas_counter.expr() + GasCost::FASTEST.expr()),
+                state_next.memory_size.expr() - state_curr.memory_size.expr(),
             ];
 
             let AddSuccessAllocation {
@@ -153,17 +154,17 @@ impl<F: FieldExt> OpGadget<F> for AddGadget<F> {
                 Lookup::BusMappingLookup(BusMappingLookup::Stack {
                     index_offset: 0.expr(),
                     value: a.expr(),
-                    is_write: false,
+                    is_write: false.expr(),
                 }),
                 Lookup::BusMappingLookup(BusMappingLookup::Stack {
                     index_offset: 1.expr(),
                     value: swap.expr() * c.expr() + no_swap.clone() * b.expr(),
-                    is_write: false,
+                    is_write: false.expr(),
                 }),
                 Lookup::BusMappingLookup(BusMappingLookup::Stack {
                     index_offset: 1.expr(),
                     value: swap.expr() * b.expr() + no_swap * c.expr(),
-                    is_write: true,
+                    is_write: true.expr(),
                 }),
             ];
 
@@ -302,7 +303,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/byte.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/byte.rs
@@ -112,6 +112,7 @@ impl<F: FieldExt> ByteSuccessCase<F> {
             sp_delta: Some(SP_DELTA.expr()),
             pc_delta: Some(PC_DELTA.expr()),
             gas_delta: Some(GAS.expr()),
+            ..utils::StateTransitions::default()
         }
         .constraints(&mut cb, state_curr, state_next);
 
@@ -151,7 +152,7 @@ impl<F: FieldExt> ByteSuccessCase<F> {
         state.global_counter += GC_DELTA;
         state.program_counter += PC_DELTA;
         state.stack_pointer += SP_DELTA;
-        state.gas_counter += GAS.as_usize();
+        state.gas_counter += GAS.as_u64();
 
         Ok(())
     }
@@ -171,7 +172,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/comparator.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/comparator.rs
@@ -113,6 +113,7 @@ impl<F: FieldExt> OpGadget<F> for LtGadget<F> {
                     - (state_curr.program_counter.expr() + 1.expr()),
                 state_next.gas_counter.expr()
                     - (state_curr.gas_counter.expr() + GasCost::FASTEST.expr()),
+                state_next.memory_size.expr() - state_curr.memory_size.expr(),
             ];
 
             let LtSuccessAllocation {
@@ -224,17 +225,17 @@ impl<F: FieldExt> OpGadget<F> for LtGadget<F> {
                 Lookup::BusMappingLookup(BusMappingLookup::Stack {
                     index_offset: 0.expr(),
                     value: swap.expr() * b.expr() + no_swap.clone() * a.expr(),
-                    is_write: false,
+                    is_write: false.expr(),
                 }),
                 Lookup::BusMappingLookup(BusMappingLookup::Stack {
                     index_offset: 1.expr(),
                     value: swap.expr() * a.expr() + no_swap * b.expr(),
-                    is_write: false,
+                    is_write: false.expr(),
                 }),
                 Lookup::BusMappingLookup(BusMappingLookup::Stack {
                     index_offset: 1.expr(),
                     value: result.expr(),
-                    is_write: true,
+                    is_write: true.expr(),
                 }),
             ];
 
@@ -393,7 +394,7 @@ mod test {
         ($execution_step:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_step, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/dup.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/dup.rs
@@ -115,6 +115,7 @@ impl<F: FieldExt> OpGadget<F> for DupGadget<F> {
                     - (state_curr.stack_pointer.expr() - 1.expr()),
                 state_next.gas_counter.expr()
                     - (state_curr.gas_counter.expr() + GasCost::FASTEST.expr()),
+                state_next.memory_size.expr() - state_curr.memory_size.expr(),
             ];
 
             let DupSuccessAllocation {
@@ -127,12 +128,12 @@ impl<F: FieldExt> OpGadget<F> for DupGadget<F> {
                 vec![Lookup::BusMappingLookup(BusMappingLookup::Stack {
                     index_offset: num_duplicated.clone() - 1.expr(),
                     value: word.expr(),
-                    is_write: false,
+                    is_write: false.expr(),
                 })],
                 vec![Lookup::BusMappingLookup(BusMappingLookup::Stack {
                     index_offset: (-1).expr(), // fixed as DUP decreases the stack pointer
                     value: word.expr(),
-                    is_write: true,
+                    is_write: true.expr(),
                 })],
             ]
             .concat();
@@ -265,7 +266,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/memory.rs
@@ -1,0 +1,612 @@
+use super::super::{Case, Cell, Constraint, ExecutionStep, Word};
+use super::utils::constraint_builder::ConstraintBuilder;
+use super::utils::math_gadgets::{
+    ComparisonGadget, IsEqualGadget, IsZeroGadget,
+};
+use super::utils::memory_gadgets::{
+    self, address_high, address_low, MemoryExpansionGadget,
+};
+use super::utils::{self, MAX_MEMORY_SIZE_IN_BYTES};
+use super::{
+    CaseAllocation, CaseConfig, CoreStateInstance, OpExecutionState, OpGadget,
+};
+use crate::impl_op_gadget;
+use crate::util::{Expr, ToWord};
+use bus_mapping::evm::{GasCost, OpcodeId};
+use halo2::plonk::Error;
+use halo2::{arithmetic::FieldExt, circuit::Region};
+use std::convert::TryInto;
+
+const GC_DELTA: u64 = 34; // 2 stack + 32 memory
+const PC_DELTA: u64 = 1;
+const SP_DELTA_MLOAD: u64 = 0;
+const SP_DELTA_MSTORE: u64 = 2;
+const GAS: GasCost = GasCost::FASTEST;
+const NUM_POPPED_MLOAD: usize = 2;
+const NUM_POPPED_MSTORE: usize = 1;
+
+impl_op_gadget!(
+    [MLOAD, MSTORE]
+    MemoryGadget {
+        MemorySuccessCase(),
+        MemoryStackUnderflowCase(),
+        MemoryOutOfGasCase(),
+    }
+);
+
+#[derive(Clone, Debug)]
+struct MemorySuccessCase<F> {
+    case_selector: Cell<F>,
+    address: Word<F>,
+    value: Word<F>,
+    call_id: Cell<F>,
+    memory_expansion: MemoryExpansionGadget<F>,
+    is_mload: IsEqualGadget<F>,
+}
+
+impl<F: FieldExt> MemorySuccessCase<F> {
+    pub(crate) const CASE_CONFIG: &'static CaseConfig = &CaseConfig {
+        case: Case::Success,
+        num_word: 2  // value + address
+            + MemoryExpansionGadget::<F>::NUM_WORDS
+            + IsEqualGadget::<F>::NUM_WORDS,
+        num_cell: 1  // call_id
+            + MemoryExpansionGadget::<F>::NUM_CELLS
+            + IsEqualGadget::<F>::NUM_CELLS,
+        will_halt: false,
+    };
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        Self {
+            case_selector: alloc.selector.clone(),
+            address: alloc.words.pop().unwrap(),
+            value: alloc.words.pop().unwrap(),
+            call_id: alloc.cells.pop().unwrap(),
+            memory_expansion: MemoryExpansionGadget::construct(alloc),
+            is_mload: IsEqualGadget::construct(alloc),
+        }
+    }
+
+    pub(crate) fn constraint(
+        &self,
+        state_curr: &OpExecutionState<F>,
+        state_next: &OpExecutionState<F>,
+        name: &'static str,
+    ) -> Constraint<F> {
+        let mut cb = ConstraintBuilder::with_call_id(self.call_id.expr());
+
+        // Check if this is an MLOAD or an MSTORE
+        let is_mload = self.is_mload.constraints(
+            &mut cb,
+            state_curr.opcode.expr(),
+            OpcodeId::MLOAD.expr(),
+        );
+        let is_mstore = 1.expr() - is_mload.clone();
+
+        // Not all address bytes are used to calculate the gas cost for the memory access,
+        // so make sure this success case is disabled if any of those address bytes
+        // are actually used.
+        memory_gadgets::require_address_in_range(&mut cb, &self.address);
+        // Get the capped address value we will use in the memory calculations
+        let address = address_low::expr(&self.address);
+
+        // Calculate the next memory size and the gas cost for this memory access
+        let (next_memory_size, memory_cost) =
+            self.memory_expansion.constraints(
+                &mut cb,
+                state_curr.memory_size.expr(),
+                address.clone() + 32.expr(),
+            );
+
+        /* Stack operations */
+        // Pop the address from the stack
+        cb.stack_pop(self.address.expr());
+        // For MLOAD push the value to the stack
+        // FOR MSTORE pop the value from the stack
+        let stack_offset = cb.stack_offset.expr() - is_mload.clone();
+        cb.stack_lookup(stack_offset, self.value.expr(), is_mload);
+
+        /* Memory operations */
+        // Read/Write the value from memory at the specified address
+        cb.memory_lookup(
+            address,
+            self.value.cells.iter().map(|cell| cell.expr()).collect(),
+            is_mstore.clone(),
+        );
+
+        // State transitions
+        utils::StateTransitions {
+            gc_delta: Some(GC_DELTA.expr()),
+            sp_delta: Some(is_mstore * 2.expr()),
+            pc_delta: Some(PC_DELTA.expr()),
+            gas_delta: Some(GAS.expr() + memory_cost),
+            next_memory_size: Some(next_memory_size),
+        }
+        .constraints(&mut cb, state_curr, state_next);
+
+        // Generate the constraint
+        cb.constraint(self.case_selector.expr(), name)
+    }
+
+    fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        state: &mut CoreStateInstance,
+        step: &ExecutionStep,
+    ) -> Result<(), Error> {
+        // Inputs/Outputs
+        self.address
+            .assign(region, offset, Some(step.values[0].to_word()))?;
+        self.value
+            .assign(region, offset, Some(step.values[1].to_word()))?;
+
+        // The call id of the current call context
+        self.call_id.assign(
+            region,
+            offset,
+            Some(F::from_u64(state.call_id as u64)),
+        )?;
+
+        // Check if this is an MLOAD or an MSTORE
+        let is_mload = self.is_mload.assign(
+            region,
+            offset,
+            F::from_u64(step.opcode.as_u8() as u64),
+            F::from_u64(OpcodeId::MLOAD.as_u8() as u64),
+        )?;
+
+        // Memory expansion
+        let address = address_low::value::<F>(step.values[0].to_word());
+        let (new_memory_size, memory_cost) = self.memory_expansion.assign(
+            region,
+            offset,
+            state.memory_size as u64,
+            address + 32,
+        )?;
+
+        // State transitions
+        state.global_counter += GC_DELTA as usize;
+        state.program_counter += PC_DELTA as usize;
+        state.stack_pointer += (if is_mload == F::from_u64(1u64) {
+            SP_DELTA_MLOAD
+        } else {
+            SP_DELTA_MSTORE
+        }) as usize;
+        state.gas_counter += GAS.as_u64() + (memory_cost as u64);
+        state.memory_size = new_memory_size;
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+struct MemoryOutOfGasCase<F> {
+    case_selector: Cell<F>,
+    gas_available: Cell<F>,
+    address: Word<F>,
+    address_in_range: IsZeroGadget<F>,
+    memory_expansion: MemoryExpansionGadget<F>,
+    insufficient_gas: ComparisonGadget<F, { MAX_MEMORY_SIZE_IN_BYTES * 2 - 1 }>,
+}
+
+impl<F: FieldExt> MemoryOutOfGasCase<F> {
+    pub(crate) const CASE_CONFIG: &'static CaseConfig = &CaseConfig {
+        case: Case::OutOfGas,
+        num_word: 1  // address
+            + IsZeroGadget::<F>::NUM_WORDS
+            + MemoryExpansionGadget::<F>::NUM_WORDS
+            + ComparisonGadget::<F, {MAX_MEMORY_SIZE_IN_BYTES*2-1}>::NUM_WORDS,
+        num_cell: IsZeroGadget::<F>::NUM_CELLS
+            + MemoryExpansionGadget::<F>::NUM_CELLS
+            + ComparisonGadget::<F, {MAX_MEMORY_SIZE_IN_BYTES*2-1}>::NUM_CELLS,
+        will_halt: true,
+    };
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        Self {
+            case_selector: alloc.selector.clone(),
+            gas_available: alloc.resumption.clone().unwrap().gas_available,
+            address: alloc.words.pop().unwrap(),
+            address_in_range: IsZeroGadget::construct(alloc),
+            memory_expansion: MemoryExpansionGadget::construct(alloc),
+            insufficient_gas: ComparisonGadget::construct(alloc),
+        }
+    }
+
+    pub(crate) fn constraint(
+        &self,
+        state_curr: &OpExecutionState<F>,
+        _state_next: &OpExecutionState<F>,
+        name: &'static str,
+    ) -> Constraint<F> {
+        let mut cb = ConstraintBuilder::default();
+
+        // Get the capped address value we will use in the memory calculations
+        let address = address_low::expr(&self.address);
+        // Get the next memory size and the gas cost for this memory access
+        let (_, memory_cost) = self.memory_expansion.constraints(
+            &mut cb,
+            state_curr.memory_size.expr(),
+            address + 32.expr(),
+        );
+
+        // Check if the memory address is too large
+        let address_in_range = self
+            .address_in_range
+            .constraints(&mut cb, address_high::expr(&self.address));
+        // Check if the amount of gas available is less than the amount of gas required
+        let insufficient_gas = self.insufficient_gas.constraints(
+            &mut cb,
+            self.gas_available.expr(),
+            state_curr.gas_counter.expr() + GAS.expr() + memory_cost,
+        );
+
+        // Make sure we are out of gas
+        // Out of gas when either the address is too big and/or the amount of gas
+        // available is lower than what is required.
+        cb.require_zero(address_in_range * (1.expr() - insufficient_gas));
+
+        // Pop the address from the stack
+        // We still have to do this to verify the correctness of `address`
+        cb.stack_pop(self.address.expr());
+
+        // Generate the constraint
+        cb.constraint(self.case_selector.expr(), name)
+    }
+
+    fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        state: &mut CoreStateInstance,
+        step: &ExecutionStep,
+    ) -> Result<(), Error> {
+        // Inputs
+        self.address
+            .assign(region, offset, Some(step.values[0].to_word()))?;
+
+        // Address in range check
+        let address = address_low::value::<F>(step.values[0].to_word());
+        self.address_in_range.assign(
+            region,
+            offset,
+            (address as u64).into(),
+        )?;
+
+        // Memory expansion
+        let address = address_low::value::<F>(step.values[0].to_word());
+        let (_memory_size, memory_cost) = self.memory_expansion.assign(
+            region,
+            offset,
+            state.memory_size as u64,
+            address + 32,
+        )?;
+
+        // Gas insufficient check
+        // Get `gas_available` variable here once it's available
+        self.insufficient_gas.assign(
+            region,
+            offset,
+            F::from_u64(
+                state.gas_counter + GAS.as_u64() + (memory_cost as u64),
+            ),
+            F::from_bytes(&step.values[1].to_word()).unwrap(),
+        )?;
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct MemoryStackUnderflowCase<F> {
+    case_selector: Cell<F>,
+    is_mstore: IsEqualGadget<F>,
+}
+
+impl<F: FieldExt> MemoryStackUnderflowCase<F> {
+    pub(crate) const CASE_CONFIG: &'static CaseConfig = &CaseConfig {
+        case: Case::StackUnderflow,
+        num_word: IsEqualGadget::<F>::NUM_WORDS,
+        num_cell: IsEqualGadget::<F>::NUM_CELLS,
+        will_halt: true,
+    };
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        Self {
+            case_selector: alloc.selector.clone(),
+            is_mstore: IsEqualGadget::construct(alloc),
+        }
+    }
+
+    pub(crate) fn constraint(
+        &self,
+        state_curr: &OpExecutionState<F>,
+        _state_next: &OpExecutionState<F>,
+        name: &'static str,
+    ) -> Constraint<F> {
+        let mut cb = ConstraintBuilder::default();
+
+        // Check if this is an MLOAD or an MSTORE
+        let is_mstore = self.is_mstore.constraints(
+            &mut cb,
+            state_curr.opcode.expr(),
+            OpcodeId::MLOAD.expr(),
+        );
+
+        // For MLOAD we only pop one value from the stack,
+        // For MSTORE we pop two values from the stack.
+        let set = vec![
+            utils::STACK_START_IDX.expr(),
+            utils::STACK_START_IDX.expr() - is_mstore,
+        ];
+        cb.require_in_set(state_curr.stack_pointer.expr(), set);
+
+        // Generate the constraint
+        cb.constraint(self.case_selector.expr(), name)
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        _state: &mut CoreStateInstance,
+        step: &ExecutionStep,
+    ) -> Result<(), Error> {
+        // Check if this is an MLOAD or an MSTORE
+        self.is_mstore.assign(
+            region,
+            offset,
+            F::from_u64(step.opcode.as_u8() as u64),
+            F::from_u64(OpcodeId::MSTORE.as_u8() as u64),
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::super::{
+        test::TestCircuit, Case, ExecutionStep, Operation,
+    };
+    use crate::util::ToWord;
+    use bus_mapping::{evm::OpcodeId, operation::Target};
+    use halo2::{arithmetic::FieldExt, dev::MockProver};
+    use num::BigUint;
+    use pasta_curves::pallas::Base;
+
+    macro_rules! try_test_circuit {
+        ($execution_steps:expr, $operations:expr, $result:expr) => {{
+            let circuit =
+                TestCircuit::<Base>::new($execution_steps, $operations);
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
+            assert_eq!(prover.verify(), $result);
+        }};
+    }
+
+    /// Helper to track gc
+    /// The `gc` parameter will be modified inside this macro.
+    macro_rules! advance_gc {
+        ($gc:ident) => {{
+            #[allow(unused_assignments, clippy::eval_order_dependence)]
+            {
+                *$gc += 1;
+                *$gc
+            }
+        }};
+    }
+
+    fn compress(bytes: [u8; 32]) -> Base {
+        bytes
+            .iter()
+            .fold(Base::zero(), |acc, val| acc + Base::from_u64(*val as u64))
+    }
+
+    fn mstore_ops(
+        operations: &mut Vec<Operation<Base>>,
+        gc: &mut usize,
+        stack_index: u64,
+        address: BigUint,
+        value: BigUint,
+    ) {
+        operations.push(Operation {
+            gc: advance_gc!(gc),
+            target: Target::Stack,
+            is_write: true,
+            values: [
+                Base::zero(),
+                Base::from_u64(stack_index),
+                compress(value.to_word()),
+                Base::zero(),
+            ],
+        });
+        operations.push(Operation {
+            gc: advance_gc!(gc),
+            target: Target::Stack,
+            is_write: true,
+            values: [
+                Base::zero(),
+                Base::from_u64(stack_index - 1),
+                compress(address.to_word()),
+                Base::zero(),
+            ],
+        });
+        operations.push(Operation {
+            gc: advance_gc!(gc),
+            target: Target::Stack,
+            is_write: false,
+            values: [
+                Base::zero(),
+                Base::from_u64(stack_index - 1),
+                compress(address.to_word()),
+                Base::zero(),
+            ],
+        });
+        operations.push(Operation {
+            gc: advance_gc!(gc),
+            target: Target::Stack,
+            is_write: false,
+            values: [
+                Base::zero(),
+                Base::from_u64(stack_index),
+                compress(value.to_word()),
+                Base::zero(),
+            ],
+        });
+        for idx in 0..32 {
+            operations.push(Operation {
+                gc: advance_gc!(gc),
+                target: Target::Memory,
+                is_write: true,
+                values: [
+                    Base::zero(),
+                    Base::from_bytes(
+                        &(address.clone() + BigUint::from(idx as u64))
+                            .to_word(),
+                    )
+                    .unwrap(),
+                    Base::from_u64(
+                        value.to_bytes_le()[31 - idx as usize] as u64,
+                    ),
+                    Base::zero(),
+                ],
+            });
+        }
+    }
+
+    fn mload_ops(
+        operations: &mut Vec<Operation<Base>>,
+        gc: &mut usize,
+        stack_index: u64,
+        address: BigUint,
+        value: BigUint,
+    ) {
+        operations.push(Operation {
+            gc: advance_gc!(gc),
+            target: Target::Stack,
+            is_write: true,
+            values: [
+                Base::zero(),
+                Base::from_u64(stack_index),
+                compress(address.to_word()),
+                Base::zero(),
+            ],
+        });
+        operations.push(Operation {
+            gc: advance_gc!(gc),
+            target: Target::Stack,
+            is_write: false,
+            values: [
+                Base::zero(),
+                Base::from_u64(stack_index),
+                compress(address.to_word()),
+                Base::zero(),
+            ],
+        });
+        operations.push(Operation {
+            gc: advance_gc!(gc),
+            target: Target::Stack,
+            is_write: true,
+            values: [
+                Base::zero(),
+                Base::from_u64(stack_index),
+                compress(value.to_word()),
+                Base::zero(),
+            ],
+        });
+        for idx in 0..32 {
+            operations.push(Operation {
+                gc: advance_gc!(gc),
+                target: Target::Memory,
+                is_write: false,
+                values: [
+                    Base::zero(),
+                    Base::from_bytes(
+                        &(address.clone() + BigUint::from(idx as u64))
+                            .to_word(),
+                    )
+                    .unwrap(),
+                    Base::from_u64(
+                        value.to_bytes_le()[31 - idx as usize] as u64,
+                    ),
+                    Base::zero(),
+                ],
+            });
+        }
+    }
+
+    #[test]
+    fn memory_gadget() {
+        // Store/Load a value at address 0x12FFFF
+        let address_a = BigUint::from(0x12FFFFu64);
+        let value_a =
+            BigUint::from_bytes_be(&(1u8..33u8).collect::<Vec<u8>>()[..]);
+
+        // Load the memory at address_a + 16 as well
+        let address_b = address_a.clone() + BigUint::from(16u64);
+        let value_b = BigUint::from_bytes_be(
+            &value_a.to_bytes_be()[16..]
+                .to_vec()
+                .into_iter()
+                .chain(
+                    vec![0u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+                        .into_iter(),
+                )
+                .collect::<Vec<u8>>()[..],
+        );
+
+        let all_ones = BigUint::from_bytes_le(&[1u8; 32]);
+
+        let execution_steps = vec![
+            ExecutionStep {
+                opcode: OpcodeId::PUSH32,
+                case: Case::Success,
+                values: vec![value_a.clone(), all_ones.clone()],
+            },
+            ExecutionStep {
+                opcode: OpcodeId::PUSH32,
+                case: Case::Success,
+                values: vec![address_a.clone(), all_ones.clone()],
+            },
+            ExecutionStep {
+                opcode: OpcodeId::MSTORE,
+                case: Case::Success,
+                values: vec![address_a.clone(), value_a.clone()],
+            },
+            ExecutionStep {
+                opcode: OpcodeId::PUSH32,
+                case: Case::Success,
+                values: vec![address_a.clone(), all_ones.clone()],
+            },
+            ExecutionStep {
+                opcode: OpcodeId::MLOAD,
+                case: Case::Success,
+                values: vec![address_a.clone(), value_a.clone()],
+            },
+            ExecutionStep {
+                opcode: OpcodeId::PUSH32,
+                case: Case::Success,
+                values: vec![address_b.clone(), all_ones],
+            },
+            ExecutionStep {
+                opcode: OpcodeId::MLOAD,
+                case: Case::Success,
+                values: vec![address_b.clone(), value_b.clone()],
+            },
+        ];
+
+        let mut gc = 0usize;
+        let mut operations = vec![];
+        mstore_ops(
+            &mut operations,
+            &mut gc,
+            1023u64,
+            address_a.clone(),
+            value_a.clone(),
+        );
+        mload_ops(&mut operations, &mut gc, 1023u64, address_a, value_a);
+        mload_ops(&mut operations, &mut gc, 1022u64, address_b, value_b);
+
+        try_test_circuit!(execution_steps, operations, Ok(()));
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/op_execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/memory.rs
@@ -49,8 +49,7 @@ impl<F: FieldExt> MemorySuccessCase<F> {
         num_word: 2  // value + address
             + MemoryExpansionGadget::<F, MAX_GAS_SIZE_IN_BYTES>::NUM_WORDS
             + IsEqualGadget::<F>::NUM_WORDS,
-        num_cell: 1  // call_id
-            + MemoryExpansionGadget::<F, MAX_GAS_SIZE_IN_BYTES>::NUM_CELLS
+        num_cell: MemoryExpansionGadget::<F, MAX_GAS_SIZE_IN_BYTES>::NUM_CELLS
             + IsEqualGadget::<F>::NUM_CELLS,
         will_halt: false,
     };

--- a/zkevm-circuits/src/evm_circuit/op_execution/memory.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/memory.rs
@@ -322,7 +322,7 @@ impl<F: FieldExt> MemoryStackUnderflowCase<F> {
         let is_mstore = self.is_mstore.constraints(
             &mut cb,
             state_curr.opcode.expr(),
-            OpcodeId::MLOAD.expr(),
+            OpcodeId::MSTORE.expr(),
         );
 
         // For MLOAD we only pop one value from the stack,

--- a/zkevm-circuits/src/evm_circuit/op_execution/pc.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/pc.rs
@@ -77,6 +77,7 @@ impl<F: FieldExt> PcSuccessCase<F> {
             sp_delta: Some(SP_DELTA.expr()),
             pc_delta: Some(PC_DELTA.expr()),
             gas_delta: Some(GAS.expr()),
+            ..utils::StateTransitions::default()
         }
         .constraints(&mut cb, state_curr, state_next);
 
@@ -94,7 +95,7 @@ impl<F: FieldExt> PcSuccessCase<F> {
         core_state.global_counter += 1;
         core_state.program_counter += 1;
         core_state.stack_pointer -= 1;
-        core_state.gas_counter += GasCost::QUICK.as_usize();
+        core_state.gas_counter += GasCost::QUICK.as_u64();
 
         self.pc.assign(
             region,
@@ -120,7 +121,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/pop.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/pop.rs
@@ -78,6 +78,8 @@ impl<F: FieldExt> OpGadget<F> for PopGadget<F> {
                 op_execution_state_next.gas_counter.expr()
                     - (op_execution_state_curr.gas_counter.expr()
                         + GasCost::QUICK.expr()),
+                op_execution_state_next.memory_size.expr()
+                    - op_execution_state_curr.memory_size.expr(),
             ];
 
             let case_selector = &self.success;
@@ -191,7 +193,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/push.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/push.rs
@@ -127,6 +127,7 @@ impl<F: FieldExt> OpGadget<F> for PushGadget<F> {
                     - (state_curr.stack_pointer.expr() - 1.expr()),
                 state_next.gas_counter.expr()
                     - (state_curr.gas_counter.expr() + GasCost::FASTEST.expr()),
+                state_next.memory_size.expr() - state_curr.memory_size.expr(),
             ];
 
             let PushSuccessAllocation {
@@ -162,7 +163,7 @@ impl<F: FieldExt> OpGadget<F> for PushGadget<F> {
                 [vec![Lookup::BusMappingLookup(BusMappingLookup::Stack {
                     index_offset: (-1).expr(),
                     value: word.expr(),
-                    is_write: true,
+                    is_write: true.expr(),
                 })]]
                 .concat();
 
@@ -279,7 +280,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/signextend.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/signextend.rs
@@ -161,6 +161,7 @@ impl<F: FieldExt> SignextendSuccessCase<F> {
             sp_delta: Some(SP_DELTA.expr()),
             pc_delta: Some(PC_DELTA.expr()),
             gas_delta: Some(GAS.expr()),
+            ..utils::StateTransitions::default()
         }
         .constraints(&mut cb, state_curr, state_next);
 
@@ -221,7 +222,7 @@ impl<F: FieldExt> SignextendSuccessCase<F> {
         state.global_counter += GC_DELTA;
         state.program_counter += PC_DELTA;
         state.stack_pointer += SP_DELTA;
-        state.gas_counter += GAS.as_usize();
+        state.gas_counter += GAS.as_u64();
 
         Ok(())
     }
@@ -241,7 +242,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/swap.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/swap.rs
@@ -109,6 +109,7 @@ impl<F: FieldExt> OpGadget<F> for SwapGadget<F> {
                     - state_curr.stack_pointer.expr(),
                 state_next.gas_counter.expr()
                     - (state_curr.gas_counter.expr() + GasCost::FASTEST.expr()),
+                state_next.memory_size.expr() - state_curr.memory_size.expr(),
             ];
 
             /*
@@ -123,24 +124,24 @@ impl<F: FieldExt> OpGadget<F> for SwapGadget<F> {
                 Lookup::BusMappingLookup(BusMappingLookup::Stack {
                     index_offset: num_swaped.clone(),
                     value: words[0].expr(),
-                    is_write: false,
+                    is_write: false.expr(),
                 }),
                 // constrain top value of stack
                 Lookup::BusMappingLookup(BusMappingLookup::Stack {
                     index_offset: 0.expr(),
                     value: words[1].expr(),
-                    is_write: false,
+                    is_write: false.expr(),
                 }),
                 // constrains when swap done
                 Lookup::BusMappingLookup(BusMappingLookup::Stack {
                     index_offset: num_swaped.clone(),
                     value: words[1].expr(),
-                    is_write: true,
+                    is_write: true.expr(),
                 }),
                 Lookup::BusMappingLookup(BusMappingLookup::Stack {
                     index_offset: 0.expr(),
                     value: words[0].expr(),
-                    is_write: true,
+                    is_write: true.expr(),
                 }),
             ];
 
@@ -252,7 +253,7 @@ mod test {
         ($execution_steps:expr, $operations:expr, $result:expr) => {{
             let circuit =
                 TestCircuit::<Base>::new($execution_steps, $operations);
-            let prover = MockProver::<Base>::run(10, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), $result);
         }};
     }

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils.rs
@@ -12,7 +12,7 @@ pub(crate) mod math_gadgets;
 pub(crate) mod memory_gadgets;
 
 pub const STACK_START_IDX: usize = 1024;
-pub const MAX_SIZE_GAS_IN_BYTES: usize = 8;
+pub const MAX_GAS_SIZE_IN_BYTES: usize = 8;
 // Number of bytes that will be used of the address word.
 // If any of the other more signficant bytes are used it will
 // always result in an out-of-gas error.

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils/common_cases.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils/common_cases.rs
@@ -7,8 +7,6 @@ use crate::util::Expr;
 use halo2::plonk::Error;
 use halo2::{arithmetic::FieldExt, circuit::Region};
 
-pub const STACK_START_IDX: usize = 1024;
-
 #[derive(Clone, Debug)]
 pub(crate) struct OutOfGasCase<F> {
     case_selector: Cell<F>,
@@ -102,7 +100,7 @@ impl<F: FieldExt> StackUnderflowCase<F> {
         name: &'static str,
     ) -> Constraint<F> {
         let set = (0..self.num_popped)
-            .map(|i| (STACK_START_IDX - i).expr())
+            .map(|i| (super::STACK_START_IDX - i).expr())
             .collect();
         let mut cb = ConstraintBuilder::default();
         cb.require_in_set(state_curr.stack_pointer.expr(), set);

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils/constraint_builder.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils/constraint_builder.rs
@@ -12,6 +12,7 @@ pub struct ConstraintBuilder<F> {
     pub expressions: Vec<Expression<F>>,
     pub(crate) lookups: Vec<Lookup<F>>,
     pub stack_offset: i32,
+    pub gc_offset: usize,
     pub call_id: Option<Expression<F>>,
     pub max_degree: usize,
 }
@@ -34,6 +35,7 @@ impl<F: FieldExt> ConstraintBuilder<F> {
             expressions: vec![],
             lookups: vec![],
             stack_offset: 0,
+            gc_offset: 0,
             call_id,
             max_degree,
         }
@@ -108,47 +110,30 @@ impl<F: FieldExt> ConstraintBuilder<F> {
             value,
             is_write,
         }));
+        self.gc_offset += 1;
     }
 
     // Memory
 
-    pub(crate) fn memory_write(
-        &mut self,
-        address: Expression<F>,
-        bytes: Vec<Expression<F>>,
-    ) {
-        self.memory_lookup(address, bytes, true.expr())
-    }
-
-    pub(crate) fn memory_read(
-        &mut self,
-        address: Expression<F>,
-        bytes: Vec<Expression<F>>,
-    ) {
-        self.memory_lookup(address, bytes, false.expr());
-    }
-
     pub(crate) fn memory_lookup(
         &mut self,
+        gc_offset: Expression<F>,
         address: Expression<F>,
-        bytes: Vec<Expression<F>>,
+        byte: Expression<F>,
         is_write: Expression<F>,
     ) {
         self.validate_lookup_expression(&self.call_id.clone().unwrap());
+        self.validate_lookup_expression(&gc_offset);
         self.validate_lookup_expression(&address);
+        self.validate_lookup_expression(&byte);
         self.validate_lookup_expression(&is_write);
-        for idx in 0..bytes.len() {
-            self.validate_lookup_expression(&bytes[idx]);
-            self.add_lookup(Lookup::BusMappingLookup(
-                BusMappingLookup::Memory {
-                    call_id: self.call_id.clone().unwrap(),
-                    index: address.clone()
-                        + Expression::Constant(F::from_u64(idx as u64)),
-                    value: bytes[bytes.len() - 1 - idx].clone(),
-                    is_write: is_write.clone(),
-                },
-            ));
-        }
+        self.add_lookup(Lookup::BusMappingLookup(BusMappingLookup::Memory {
+            call_id: self.call_id.clone().unwrap(),
+            index: address,
+            value: byte,
+            is_write,
+            gc_offset,
+        }));
     }
 
     // Validation

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils/math_gadgets.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils/math_gadgets.rs
@@ -183,6 +183,7 @@ impl<F: FieldExt, const NUM_BYTES: usize> ConstantDivisionGadget<F, NUM_BYTES> {
             self.quotient.expr() * self.divisor.expr(),
         );
 
+        // Return the quotient and the remainder
         (self.quotient.expr(), self.remainder.expr())
     }
 
@@ -239,7 +240,7 @@ impl<F: FieldExt, const NUM_BYTES: usize> ComparisonGadget<F, NUM_BYTES> {
         lhs: Expression<F>,
         rhs: Expression<F>,
     ) -> Expression<F> {
-        let diff = utils::from_bytes::expr(self.diff[0..NUM_BYTES].to_vec());
+        let diff = utils::from_bytes::expr(self.diff.to_vec());
         // The comparison equation that needs to hold.
         cb.require_equal(lhs, rhs + diff - (self.lt.expr() * self.range));
 

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils/math_gadgets.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils/math_gadgets.rs
@@ -1,12 +1,14 @@
+use super::super::utils;
 use super::super::CaseAllocation;
 use super::super::Cell;
 use crate::util::Expr;
+use array_init::array_init;
 use halo2::plonk::Error;
 use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Expression};
 
 use super::constraint_builder::ConstraintBuilder;
 
-// Returns `1` when `value == 0`, and returns `0` otherwise.
+/// Returns `1` when `value == 0`, and returns `0` otherwise.
 #[derive(Clone, Debug)]
 pub struct IsZeroGadget<F> {
     pub(crate) inverse: Cell<F>,
@@ -48,7 +50,7 @@ impl<F: FieldExt> IsZeroGadget<F> {
     }
 }
 
-// Returns `1` when `lhs == rhs`, and returns `0` otherwise.
+/// Returns `1` when `lhs == rhs`, and returns `0` otherwise.
 #[derive(Clone, Debug)]
 pub struct IsEqualGadget<F> {
     pub(crate) is_zero: IsZeroGadget<F>,
@@ -81,5 +83,242 @@ impl<F: FieldExt> IsEqualGadget<F> {
         rhs: F,
     ) -> Result<F, Error> {
         self.is_zero.assign(region, offset, lhs - rhs)
+    }
+}
+
+/// Requires that the passed in value is within the specified range.
+/// `NUM_BYTES` is required to be `<= 31`.
+#[derive(Clone, Debug)]
+pub struct RangeCheckGadget<F, const NUM_BYTES: usize> {
+    parts: [Cell<F>; NUM_BYTES],
+}
+
+impl<F: FieldExt, const NUM_BYTES: usize> RangeCheckGadget<F, NUM_BYTES> {
+    pub const NUM_CELLS: usize = NUM_BYTES;
+    pub const NUM_WORDS: usize = 0;
+
+    pub const PART_SIZE: u64 = 256;
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        assert!(NUM_BYTES <= 31, "number of bytes too large");
+        Self {
+            parts: array_init(|_| alloc.cells.pop().unwrap()),
+        }
+    }
+
+    pub(crate) fn constraints(
+        &self,
+        cb: &mut ConstraintBuilder<F>,
+        value: Expression<F>,
+    ) {
+        // Range check the parts using lookups
+        for part in self.parts.iter() {
+            cb.require_in_range(part.expr(), Self::PART_SIZE);
+        }
+        // Require that the reconstructed value from the parts equals the original value
+        cb.require_equal(value, utils::from_bytes::expr(self.parts.to_vec()));
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        value: F,
+    ) -> Result<(), Error> {
+        let bytes = value.to_bytes();
+        for (idx, part) in self.parts.iter().enumerate() {
+            part.assign(region, offset, Some(F::from_u64(bytes[idx] as u64)))?;
+        }
+        Ok(())
+    }
+}
+
+/// Returns (quotient: numerator/divisor, remainder: numerator%divisor),
+/// with `numerator` an expression and `divisor` a constant.
+/// Input requirements:
+/// - `quotient < 256**NUM_BYTES`
+/// - `quotient * divisor < field size`
+/// - `remainder < divisor` currently requires a lookup table for `divisor`
+#[derive(Clone, Debug)]
+pub struct ConstantDivisionGadget<F, const NUM_BYTES: usize> {
+    quotient: Cell<F>,
+    remainder: Cell<F>,
+    divisor: u64,
+    quotient_range_check: RangeCheckGadget<F, NUM_BYTES>,
+}
+
+impl<F: FieldExt, const NUM_BYTES: usize> ConstantDivisionGadget<F, NUM_BYTES> {
+    pub const NUM_CELLS: usize =
+        2 + RangeCheckGadget::<F, NUM_BYTES>::NUM_CELLS;
+    pub const NUM_WORDS: usize = RangeCheckGadget::<F, NUM_BYTES>::NUM_WORDS;
+
+    pub(crate) fn construct(
+        alloc: &mut CaseAllocation<F>,
+        divisor: u64,
+    ) -> Self {
+        Self {
+            quotient: alloc.cells.pop().unwrap(),
+            remainder: alloc.cells.pop().unwrap(),
+            divisor,
+            quotient_range_check: RangeCheckGadget::construct(alloc),
+        }
+    }
+
+    pub(crate) fn constraints(
+        &self,
+        cb: &mut ConstraintBuilder<F>,
+        numerator: Expression<F>,
+    ) -> (Expression<F>, Expression<F>) {
+        // Require that remainder < divisor
+        cb.require_in_range(self.remainder.expr(), self.divisor);
+
+        // Require that quotient < 2**NUM_BYTES
+        // so we can't have any overflow when doing `quotient * divisor`.
+        self.quotient_range_check
+            .constraints(cb, self.quotient.expr());
+
+        // Check if the division was done correctly
+        cb.require_equal(
+            numerator - self.remainder.expr(),
+            self.quotient.expr() * self.divisor.expr(),
+        );
+
+        (self.quotient.expr(), self.remainder.expr())
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        numerator: u128,
+    ) -> Result<(u128, u128), Error> {
+        let divisor = self.divisor as u128;
+        let quotient = numerator / divisor;
+        let remainder = numerator % divisor;
+        self.quotient
+            .assign(region, offset, Some(F::from_u128(quotient)))?;
+        self.remainder
+            .assign(region, offset, Some(F::from_u128(remainder)))?;
+
+        self.quotient_range_check.assign(
+            region,
+            offset,
+            F::from_u128(quotient),
+        )?;
+
+        Ok((quotient, remainder))
+    }
+}
+
+/// Returns `1` when `lhs < rhs`, and returns `0` otherwise.
+/// lhs and rhs `< 256**NUM_BYTES`
+/// `NUM_BYTES` is required to be `<= 31`.
+#[derive(Clone, Debug)]
+pub struct ComparisonGadget<F, const NUM_BYTES: usize> {
+    lt: Cell<F>,
+    diff: [Cell<F>; NUM_BYTES],
+    range: F,
+}
+
+impl<F: FieldExt, const NUM_BYTES: usize> ComparisonGadget<F, NUM_BYTES> {
+    pub const NUM_CELLS: usize = 1 + NUM_BYTES; // lt + diff
+    pub const NUM_WORDS: usize = 0;
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        assert!(NUM_BYTES <= 31, "unsupported number of bytes");
+        Self {
+            lt: alloc.cells.pop().unwrap(),
+            diff: array_init(|_| alloc.cells.pop().unwrap()),
+            range: utils::get_range(NUM_BYTES * 8),
+        }
+    }
+
+    pub(crate) fn constraints(
+        &self,
+        cb: &mut ConstraintBuilder<F>,
+        lhs: Expression<F>,
+        rhs: Expression<F>,
+    ) -> Expression<F> {
+        let diff = utils::from_bytes::expr(self.diff[0..NUM_BYTES].to_vec());
+        // The comparison equation that needs to hold.
+        cb.require_equal(lhs, rhs + diff - (self.lt.expr() * self.range));
+
+        // `lt` needs to be boolean
+        cb.require_boolean(self.lt.expr());
+        // All parts of `diff` need to be bytes
+        for byte in self.diff.iter() {
+            cb.require_in_range(byte.expr(), 256);
+        }
+
+        self.lt.expr()
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        lhs: F,
+        rhs: F,
+    ) -> Result<F, Error> {
+        // Set `lt`
+        let lt = lhs < rhs;
+        self.lt.assign(
+            region,
+            offset,
+            Some(F::from_u64(if lt { 1 } else { 0 })),
+        )?;
+
+        // Set the bytes of diff
+        let diff = (lhs - rhs) + (if lt { self.range } else { F::zero() });
+        let diff_bytes = diff.to_bytes();
+        for (idx, diff) in self.diff.iter().enumerate() {
+            diff.assign(
+                region,
+                offset,
+                Some(F::from_u64(diff_bytes[idx] as u64)),
+            )?;
+        }
+
+        Ok(if lt { F::one() } else { F::zero() })
+    }
+}
+
+/// Returns `rhs` when `lhs < rhs`, and returns `lhs` otherwise.
+/// lhs and rhs `< 256**NUM_BYTES`
+/// `NUM_BYTES` is required to be `<= 31`.
+#[derive(Clone, Debug)]
+pub struct MaxGadget<F, const NUM_BYTES: usize> {
+    comparison: ComparisonGadget<F, NUM_BYTES>,
+}
+
+impl<F: FieldExt, const NUM_BYTES: usize> MaxGadget<F, NUM_BYTES> {
+    pub const NUM_CELLS: usize = ComparisonGadget::<F, NUM_BYTES>::NUM_CELLS;
+    pub const NUM_WORDS: usize = ComparisonGadget::<F, NUM_BYTES>::NUM_WORDS;
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        Self {
+            comparison: ComparisonGadget::construct(alloc),
+        }
+    }
+
+    pub(crate) fn constraints(
+        &self,
+        cb: &mut ConstraintBuilder<F>,
+        lhs: Expression<F>,
+        rhs: Expression<F>,
+    ) -> Expression<F> {
+        let lt = self.comparison.constraints(cb, lhs.clone(), rhs.clone());
+        utils::select::expr(lt, rhs, lhs)
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        lhs: F,
+        rhs: F,
+    ) -> Result<F, Error> {
+        let lt = self.comparison.assign(region, offset, lhs, rhs)?;
+        Ok(utils::select::value(lt, rhs, lhs))
     }
 }

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils/memory_gadgets.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils/memory_gadgets.rs
@@ -1,5 +1,4 @@
-use super::super::CaseAllocation;
-use super::super::Word;
+use super::super::{CaseAllocation, Word};
 use super::constraint_builder::ConstraintBuilder;
 use super::math_gadgets::{ConstantDivisionGadget, MaxGadget};
 use super::MAX_MEMORY_SIZE_IN_BYTES;
@@ -102,22 +101,23 @@ impl<F: FieldExt> MemorySizeGadget<F> {
 /// This gas cost is the difference between the next and current memory costs:
 /// `memory_cost = Gmem * memory_size + floor(memory_size * memory_size / 512)`
 #[derive(Clone, Debug)]
-pub(crate) struct MemoryExpansionGadget<F> {
+pub(crate) struct MemoryExpansionGadget<F, const MAX_QUAD_COST_IN_BYTES: usize>
+{
     address_memory_size: MemorySizeGadget<F>,
     next_memory_size: MaxGadget<F, MAX_MEMORY_SIZE_IN_BYTES>,
-    curr_quad_memory_cost:
-        ConstantDivisionGadget<F, { MAX_MEMORY_SIZE_IN_BYTES * 2 }>,
-    next_quad_memory_cost:
-        ConstantDivisionGadget<F, { MAX_MEMORY_SIZE_IN_BYTES * 2 }>,
+    curr_quad_memory_cost: ConstantDivisionGadget<F, MAX_QUAD_COST_IN_BYTES>,
+    next_quad_memory_cost: ConstantDivisionGadget<F, MAX_QUAD_COST_IN_BYTES>,
 }
 
-impl<F: FieldExt> MemoryExpansionGadget<F> {
+impl<F: FieldExt, const MAX_QUAD_COST_IN_BYTES: usize>
+    MemoryExpansionGadget<F, MAX_QUAD_COST_IN_BYTES>
+{
     pub const NUM_CELLS: usize = MemorySizeGadget::<F>::NUM_CELLS
         + MaxGadget::<F, MAX_MEMORY_SIZE_IN_BYTES>::NUM_CELLS
-        + ConstantDivisionGadget::<F, {MAX_MEMORY_SIZE_IN_BYTES*2}>::NUM_CELLS * 2;
+        + ConstantDivisionGadget::<F, MAX_QUAD_COST_IN_BYTES>::NUM_CELLS * 2;
     pub const NUM_WORDS: usize = MemorySizeGadget::<F>::NUM_WORDS
         + MaxGadget::<F, MAX_MEMORY_SIZE_IN_BYTES>::NUM_WORDS
-        + ConstantDivisionGadget::<F, {MAX_MEMORY_SIZE_IN_BYTES*2}>::NUM_WORDS * 2;
+        + ConstantDivisionGadget::<F, MAX_QUAD_COST_IN_BYTES>::NUM_WORDS * 2;
 
     pub const GAS_MEM: GasCost = GasCost::MEMORY;
     pub const QUAD_COEFF_DIV: u64 = 512u64;
@@ -139,10 +139,10 @@ impl<F: FieldExt> MemoryExpansionGadget<F> {
 
     /// Input requirements:
     /// - `curr_memory_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
-    /// - `address` needs to be `< 32 * 256**MAX_MEMORY_SIZE_IN_BYTES`
+    /// - `address < 32 * 256**MAX_MEMORY_SIZE_IN_BYTES`
     /// Output ranges:
-    /// - `next_memory_size < 256**MAX_MEMORY_SIZE_IN_BYTES*`
-    /// - `memory_gas_cost <= 0x80000002fefffffffd < 256**(MAX_MEMORY_SIZE_IN_BYTES*2-1)`
+    /// - `next_memory_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
+    /// - `memory_gas_cost <= GAS_MEM*256**MAX_MEMORY_SIZE_IN_BYTES + 256**MAX_QUAD_COST_IN_BYTES`
     pub(crate) fn constraints(
         &self,
         cb: &mut ConstraintBuilder<F>,
@@ -164,6 +164,7 @@ impl<F: FieldExt> MemoryExpansionGadget<F> {
         );
 
         // Calculate the quad memory cost for the current and next memory size.
+        // These quad costs will also be range limited to `< 256**MAX_QUAD_COST_IN_BYTES`.
         let (curr_quad_memory_cost, _) =
             self.curr_quad_memory_cost.constraints(
                 cb,
@@ -177,7 +178,7 @@ impl<F: FieldExt> MemoryExpansionGadget<F> {
 
         // Calculate the gas cost for the memory expansion.
         // This gas cost is the difference between the next and current memory costs.
-        // `memory_cost <= 0x80000002fefffffffd < 256**(2*MAX_MEMORY_SIZE_IN_BYTES-1)`
+        // `memory_gas_cost <= GAS_MEM*256**MAX_MEMORY_SIZE_IN_BYTES + 256**MAX_QUAD_COST_IN_BYTES`
         let memory_gas_cost = (next_memory_size.clone() - curr_memory_size)
             * Self::GAS_MEM.expr()
             + (next_quad_memory_cost - curr_quad_memory_cost);

--- a/zkevm-circuits/src/evm_circuit/op_execution/utils/memory_gadgets.rs
+++ b/zkevm-circuits/src/evm_circuit/op_execution/utils/memory_gadgets.rs
@@ -1,0 +1,231 @@
+use super::super::CaseAllocation;
+use super::super::Word;
+use super::constraint_builder::ConstraintBuilder;
+use super::math_gadgets::{ConstantDivisionGadget, MaxGadget};
+use super::MAX_MEMORY_SIZE_IN_BYTES;
+use super::{Address, MemorySize};
+use crate::util::Expr;
+use bus_mapping::evm::GasCost;
+use halo2::plonk::Error;
+use halo2::{arithmetic::FieldExt, circuit::Region, plonk::Expression};
+
+/// Decodes the usable part of an address stored in a Word
+pub(crate) mod address_low {
+    use super::super::super::Word;
+    use super::super::Address;
+    use super::super::NUM_ADDRESS_BYTES_USED;
+    use crate::evm_circuit::op_execution::utils;
+    use halo2::{arithmetic::FieldExt, plonk::Expression};
+
+    pub(crate) fn expr<F: FieldExt>(address: &Word<F>) -> Expression<F> {
+        utils::from_bytes::expr(
+            address.cells[0..NUM_ADDRESS_BYTES_USED].to_vec(),
+        )
+    }
+
+    pub(crate) fn value<F: FieldExt>(address: [u8; 32]) -> Address {
+        utils::from_bytes::value::<F>(
+            address[0..NUM_ADDRESS_BYTES_USED].to_vec(),
+        )
+        .get_lower_128() as Address
+    }
+}
+
+/// The sum of bytes of the address that are unused for most calculations on the address
+pub(crate) mod address_high {
+    use super::super::super::Word;
+    use super::super::NUM_ADDRESS_BYTES_USED;
+    use crate::evm_circuit::op_execution::utils;
+    use halo2::{arithmetic::FieldExt, plonk::Expression};
+
+    pub(crate) fn expr<F: FieldExt>(address: &Word<F>) -> Expression<F> {
+        utils::sum::expr(&address.cells[NUM_ADDRESS_BYTES_USED..32].to_vec())
+    }
+
+    pub(crate) fn value<F: FieldExt>(address: [u8; 32]) -> F {
+        utils::sum::value::<F>(&address[NUM_ADDRESS_BYTES_USED..32].to_vec())
+    }
+}
+
+/// If any of the MSBs are non-zero we're always out of gas
+pub(crate) fn require_address_in_range<F: FieldExt>(
+    cb: &mut ConstraintBuilder<F>,
+    address: &Word<F>,
+) {
+    cb.require_zero(address_high::expr(address));
+}
+
+/// Calculates the memory size required for a memory access at the specified address.
+/// `memory_size = ceil(address/32) = floor((address + 31) / 32)`
+#[derive(Clone, Debug)]
+pub(crate) struct MemorySizeGadget<F> {
+    memory_size: ConstantDivisionGadget<F, MAX_MEMORY_SIZE_IN_BYTES>,
+}
+
+impl<F: FieldExt> MemorySizeGadget<F> {
+    pub const NUM_CELLS: usize =
+        ConstantDivisionGadget::<F, MAX_MEMORY_SIZE_IN_BYTES>::NUM_CELLS;
+    pub const NUM_WORDS: usize =
+        ConstantDivisionGadget::<F, MAX_MEMORY_SIZE_IN_BYTES>::NUM_WORDS;
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        Self {
+            memory_size: ConstantDivisionGadget::construct(alloc, 32),
+        }
+    }
+
+    pub(crate) fn constraints(
+        &self,
+        cb: &mut ConstraintBuilder<F>,
+        address: Expression<F>,
+    ) -> Expression<F> {
+        let (quotient, _remainder) =
+            self.memory_size.constraints(cb, address + 31.expr());
+        quotient
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        address: Address,
+    ) -> Result<MemorySize, Error> {
+        let (quotient, _) =
+            self.memory_size
+                .assign(region, offset, (address as u128) + 31)?;
+        Ok(quotient as MemorySize)
+    }
+}
+
+/// Returns (new memory size, memory gas cost) for a memory access.
+/// If the memory needs to be expanded this will result in an extra gas cost.
+/// This gas cost is the difference between the next and current memory costs:
+/// `memory_cost = Gmem * memory_size + floor(memory_size * memory_size / 512)`
+#[derive(Clone, Debug)]
+pub(crate) struct MemoryExpansionGadget<F> {
+    address_memory_size: MemorySizeGadget<F>,
+    next_memory_size: MaxGadget<F, MAX_MEMORY_SIZE_IN_BYTES>,
+    curr_quad_memory_cost:
+        ConstantDivisionGadget<F, { MAX_MEMORY_SIZE_IN_BYTES * 2 }>,
+    next_quad_memory_cost:
+        ConstantDivisionGadget<F, { MAX_MEMORY_SIZE_IN_BYTES * 2 }>,
+}
+
+impl<F: FieldExt> MemoryExpansionGadget<F> {
+    pub const NUM_CELLS: usize = MemorySizeGadget::<F>::NUM_CELLS
+        + MaxGadget::<F, MAX_MEMORY_SIZE_IN_BYTES>::NUM_CELLS
+        + ConstantDivisionGadget::<F, {MAX_MEMORY_SIZE_IN_BYTES*2}>::NUM_CELLS * 2;
+    pub const NUM_WORDS: usize = MemorySizeGadget::<F>::NUM_WORDS
+        + MaxGadget::<F, MAX_MEMORY_SIZE_IN_BYTES>::NUM_WORDS
+        + ConstantDivisionGadget::<F, {MAX_MEMORY_SIZE_IN_BYTES*2}>::NUM_WORDS * 2;
+
+    pub const GAS_MEM: GasCost = GasCost::MEMORY;
+    pub const QUAD_COEFF_DIV: u64 = 512u64;
+
+    pub(crate) fn construct(alloc: &mut CaseAllocation<F>) -> Self {
+        Self {
+            address_memory_size: MemorySizeGadget::construct(alloc),
+            next_memory_size: MaxGadget::construct(alloc),
+            curr_quad_memory_cost: ConstantDivisionGadget::construct(
+                alloc,
+                Self::QUAD_COEFF_DIV,
+            ),
+            next_quad_memory_cost: ConstantDivisionGadget::construct(
+                alloc,
+                Self::QUAD_COEFF_DIV,
+            ),
+        }
+    }
+
+    /// Input requirements:
+    /// - `curr_memory_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
+    /// - `address` needs to be `< 32 * 256**MAX_MEMORY_SIZE_IN_BYTES`
+    /// Output ranges:
+    /// - `next_memory_size < 256**MAX_MEMORY_SIZE_IN_BYTES*`
+    /// - `memory_gas_cost <= 0x80000002fefffffffd < 256**(MAX_MEMORY_SIZE_IN_BYTES*2-1)`
+    pub(crate) fn constraints(
+        &self,
+        cb: &mut ConstraintBuilder<F>,
+        curr_memory_size: Expression<F>,
+        address: Expression<F>,
+    ) -> (Expression<F>, Expression<F>) {
+        // Calculate the memory size of the memory access
+        // `address_memory_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
+        let address_memory_size =
+            self.address_memory_size.constraints(cb, address);
+
+        // The memory size needs to be updated if this memory access
+        // requires expanding the memory.
+        // `next_memory_size < 256**MAX_MEMORY_SIZE_IN_BYTES`
+        let next_memory_size = self.next_memory_size.constraints(
+            cb,
+            address_memory_size,
+            curr_memory_size.clone(),
+        );
+
+        // Calculate the quad memory cost for the current and next memory size.
+        let (curr_quad_memory_cost, _) =
+            self.curr_quad_memory_cost.constraints(
+                cb,
+                curr_memory_size.clone() * curr_memory_size.clone(),
+            );
+        let (next_quad_memory_cost, _) =
+            self.next_quad_memory_cost.constraints(
+                cb,
+                next_memory_size.clone() * next_memory_size.clone(),
+            );
+
+        // Calculate the gas cost for the memory expansion.
+        // This gas cost is the difference between the next and current memory costs.
+        // `memory_cost <= 0x80000002fefffffffd < 256**(2*MAX_MEMORY_SIZE_IN_BYTES-1)`
+        let memory_gas_cost = (next_memory_size.clone() - curr_memory_size)
+            * Self::GAS_MEM.expr()
+            + (next_quad_memory_cost - curr_quad_memory_cost);
+
+        // Return the new memory size and the memory expansion gas cost
+        (next_memory_size, memory_gas_cost)
+    }
+
+    pub(crate) fn assign(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        curr_memory_size: MemorySize,
+        address: Address,
+    ) -> Result<(MemorySize, u128), Error> {
+        // Calculate the active memory size
+        let address_memory_size =
+            self.address_memory_size.assign(region, offset, address)?;
+
+        // Calculate the next memory size
+        let next_memory_size = self
+            .next_memory_size
+            .assign(
+                region,
+                offset,
+                F::from_u64(address_memory_size),
+                F::from_u64(curr_memory_size),
+            )?
+            .get_lower_128() as MemorySize;
+
+        // Calculate the quad gas cost for the memory size
+        let (curr_quad_memory_cost, _) = self.curr_quad_memory_cost.assign(
+            region,
+            offset,
+            (curr_memory_size as u128) * (curr_memory_size as u128),
+        )?;
+        let (next_quad_memory_cost, _) = self.next_quad_memory_cost.assign(
+            region,
+            offset,
+            (next_memory_size as u128) * (next_memory_size as u128),
+        )?;
+
+        // Calculate the gas cost for the expansian
+        let memory_cost = (next_memory_size - curr_memory_size) as u128
+            * (Self::GAS_MEM.as_u64() as u128)
+            + (next_quad_memory_cost - curr_quad_memory_cost);
+
+        // Return the new memory size and the memory expansion gas cost
+        Ok((next_memory_size, memory_cost))
+    }
+}

--- a/zkevm-circuits/src/evm_circuit/param.rs
+++ b/zkevm-circuits/src/evm_circuit/param.rs
@@ -6,7 +6,7 @@ pub const CIRCUIT_HEIGHT: usize = 10;
 
 // Number of cells used for each purpose
 // TODO: pub const NUM_CELL_CALL_INITIALIZATION_STATE: usize = ;
-pub const NUM_CELL_OP_EXECUTION_STATE: usize = 7;
+pub const NUM_CELL_OP_EXECUTION_STATE: usize = 8;
 // FIXME: naive estimation, should be optmize to fit in the future
 pub const NUM_CELL_OP_GADGET_SELECTOR: usize = 80;
 pub const NUM_CELL_RESUMPTION: usize = 2;


### PR DESCRIPTION
Add MSTORE8 to `MemoryGadget` by doing 32 memory lookups (as required by MLOAD/MSTORE) but by having all the looks point to a single busmapping row.

I think it's probably best to handle all the gc logic on the constraint builder side for all the rw lookups because I don't think doing it only for memory (and for the stack for example) works well. This PR only does it for memory because not all stack ops currently go through the constraint builder so it would need to be handled explicitly in all cases. Best to first update all the op gadgets to use the constrain builder first so it can be handled there automatically if nothing special needs to be done.