### PR TITLE
[WIP] A naive impl for keccak padding.

### DIFF
--- a/circuit-benchmarks/src/keccak_padding_bench.rs
+++ b/circuit-benchmarks/src/keccak_padding_bench.rs
@@ -17,7 +17,7 @@ mod tests {
     use std::fs::File;
     use std::io::BufReader;
     use zkevm_circuits::keccak_circuit::{
-        keccak_padding::KeccakPaddingCircuit,
+        keccak_complete_bit_2::KeccakCompleteBitCircuit, keccak_padding::KeccakPaddingCircuit,
         keccak_padding_multi_gadgets::KeccakMultiGadgetPaddingCircuit,
         keccak_padding_multirows::KeccakMultiRowPaddingCircuit,
         keccak_padding_multirows_2::KeccakPaddingMultiRowsExCircuit,
@@ -174,6 +174,28 @@ mod tests {
 
         println!("type4:");
         let empty_circuit = KeccakPaddingMultiRowsExCircuit::<Fr>::default();
+        bench_circuit(empty_circuit, params, degree);
+    }
+
+    #[test]
+    fn bench_keccak_bit_complete_2_circuit_prover() {
+        let degree: u32 = var("DEGREE")
+            .unwrap_or(String::from("12"))
+            .parse()
+            .expect("Cannot parse DEGREE env var as u32");
+
+        let params: Option<Params<G1Affine>> = {
+            let params_path: String = var("PARAMS_PATH")
+                .unwrap_or(String::from(format!("./params-{}", degree)))
+                .parse()
+                .expect("Cannot parse PARAMS_PATH env var");
+            File::open(&params_path)
+                .and_then(|fs| Params::read::<_>(&mut BufReader::new(fs)))
+                .ok()
+        };
+
+        println!("KeccakPaddingMultiRowsExCircuit:");
+        let empty_circuit = KeccakCompleteBitCircuit::<Fr>::default();
         bench_circuit(empty_circuit, params, degree);
     }
 }

--- a/circuit-benchmarks/src/keccak_padding_bench.rs
+++ b/circuit-benchmarks/src/keccak_padding_bench.rs
@@ -1,0 +1,166 @@
+//! State circuit benchmarks
+
+#[cfg(test)]
+mod tests {
+    use ark_std::{end_timer, start_timer};
+    use halo2_proofs::plonk::{
+        create_proof, keygen_pk, keygen_vk, verify_proof, Circuit, SingleVerifier,
+    };
+    use halo2_proofs::{
+        pairing::bn256::{Bn256, Fr, G1Affine},
+        poly::commitment::{Params, ParamsVerifier},
+        transcript::{Blake2bRead, Blake2bWrite, Challenge255},
+    };
+    use rand::SeedableRng;
+    use rand_xorshift::XorShiftRng;
+    use std::env::var;
+    use std::fs::File;
+    use std::io::BufReader;
+    use zkevm_circuits::keccak_circuit::{
+        keccak_padding::KeccakPaddingCircuit,
+        keccak_padding_multi_gadgets::KeccakMultiGadgetPaddingCircuit,
+        keccak_padding_multirows::KeccakMultiRowPaddingCircuit,
+        keccak_padding_multirows_2::KeccakPaddingMultiRowsExCircuit,
+    };
+
+    #[cfg_attr(not(feature = "benches"), ignore)]
+    fn bench_circuit(
+        empty_circuit: impl Circuit<Fr>,
+        param: Option<Params<G1Affine>>,
+        degree: u32,
+    ) {
+        // Initialize the polynomial commitment parameters
+        let rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
+            0xbc, 0xe5,
+        ]);
+
+        // Bench setup generation
+        let setup_message = format!("Setup generation with degree = {}", degree);
+        let start1 = start_timer!(|| setup_message);
+        let general_params = match param {
+            Some(param) => param,
+            None => {
+                println!("Regenerate params with degree {}", degree);
+                let general_params: Params<G1Affine> =
+                    Params::<G1Affine>::unsafe_setup::<Bn256>(degree);
+                general_params
+            }
+        };
+        let verifier_params: ParamsVerifier<Bn256> =
+            general_params.verifier(degree as usize * 2).unwrap();
+
+        end_timer!(start1);
+
+        // Initialize the proving key
+        let vk = keygen_vk(&general_params, &empty_circuit).expect("keygen_vk should not fail");
+        let pk = keygen_pk(&general_params, vk, &empty_circuit).expect("keygen_pk should not fail");
+        // Create a proof
+        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+
+        // Bench proof generation time
+        let proof_message = format!("Packed Keccak Multi Proof generation with {} rows", degree);
+        let start2 = start_timer!(|| proof_message);
+        create_proof(
+            &general_params,
+            &pk,
+            &[empty_circuit],
+            &[&[]],
+            rng,
+            &mut transcript,
+        )
+        .expect("proof generation should not fail");
+        let proof = transcript.finalize();
+        end_timer!(start2);
+
+        // Bench verification time
+        let start3 = start_timer!(|| "Keccak Proof verification");
+        let mut verifier_transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+        let strategy = SingleVerifier::new(&verifier_params);
+
+        verify_proof(
+            &verifier_params,
+            pk.get_vk(),
+            strategy,
+            &[&[]],
+            &mut verifier_transcript,
+        )
+        .expect("failed to verify bench circuit");
+        end_timer!(start3);
+    }
+
+    #[test]
+    fn bench_naive_keccak_padding_circuit_prover() {
+        let degree: u32 = var("DEGREE").unwrap_or("12").parse()
+
+        let params: Option<Params<G1Affine>> = {
+            let params_path = format!(
+                "/home/ubuntu/works/degree/references/data/params-{}",
+                degree
+            );
+            File::open(&params_path)
+                .and_then(|fs| Params::read::<_>(&mut BufReader::new(fs)))
+                .ok()
+        };
+
+        println!("type1:");
+        let empty_circuit = KeccakPaddingCircuit::<Fr>::default();
+        bench_circuit(empty_circuit, params, degree);
+    }
+
+    #[test]
+    fn bench_keccak_padding_multi_gadgets_circuit_prover() {
+        let degree: u32 = var("DEGREE").unwrap_or("12").parse()
+
+        let params: Option<Params<G1Affine>> = {
+            let params_path = format!(
+                "/home/ubuntu/works/degree/references/data/params-{}",
+                degree
+            );
+            File::open(&params_path)
+                .and_then(|fs| Params::read::<_>(&mut BufReader::new(fs)))
+                .ok()
+        };
+        println!("type2:");
+        let empty_circuit = KeccakMultiGadgetPaddingCircuit::<Fr>::default();
+        bench_circuit(empty_circuit, params, degree);
+    }
+
+    #[test]
+    fn bench_keccak_padding_multi_row_circuit_prover() {
+        let degree: u32 = var("DEGREE").unwrap_or("12").parse()
+
+        let params: Option<Params<G1Affine>> = {
+            let params_path = format!(
+                "/home/ubuntu/works/degree/references/data/params-{}",
+                degree
+            );
+            File::open(&params_path)
+                .and_then(|fs| Params::read::<_>(&mut BufReader::new(fs)))
+                .ok()
+        };
+
+        println!("type3:");
+        let empty_circuit = KeccakMultiRowPaddingCircuit::<Fr>::default();
+        bench_circuit(empty_circuit, params, degree);
+    }
+
+    #[test]
+    fn bench_keccak_padding_multi_row_2_circuit_prover() {
+        let degree: u32 = var("DEGREE").unwrap_or("12").parse()
+
+        let params: Option<Params<G1Affine>> = {
+            let params_path = format!(
+                "/home/ubuntu/works/degree/references/data/params-{}",
+                degree
+            );
+            File::open(&params_path)
+                .and_then(|fs| Params::read::<_>(&mut BufReader::new(fs)))
+                .ok()
+        };
+
+        println!("type4:");
+        let empty_circuit = KeccakPaddingMultiRowsExCircuit::<Fr>::default();
+        bench_circuit(empty_circuit, params, degree);
+    }
+}

--- a/circuit-benchmarks/src/keccak_padding_bench.rs
+++ b/circuit-benchmarks/src/keccak_padding_bench.rs
@@ -91,7 +91,10 @@ mod tests {
 
     #[test]
     fn bench_naive_keccak_padding_circuit_prover() {
-        let degree: u32 = var("DEGREE").unwrap_or("12").parse()
+        let degree: u32 = var("DEGREE")
+            .unwrap_or(String::from("12"))
+            .parse()
+            .expect("Cannot parse DEGREE env var as u32");
 
         let params: Option<Params<G1Affine>> = {
             let params_path = format!(
@@ -110,7 +113,10 @@ mod tests {
 
     #[test]
     fn bench_keccak_padding_multi_gadgets_circuit_prover() {
-        let degree: u32 = var("DEGREE").unwrap_or("12").parse()
+        let degree: u32 = var("DEGREE")
+            .unwrap_or(String::from("12"))
+            .parse()
+            .expect("Cannot parse DEGREE env var as u32");
 
         let params: Option<Params<G1Affine>> = {
             let params_path = format!(
@@ -128,7 +134,10 @@ mod tests {
 
     #[test]
     fn bench_keccak_padding_multi_row_circuit_prover() {
-        let degree: u32 = var("DEGREE").unwrap_or("12").parse()
+        let degree: u32 = var("DEGREE")
+            .unwrap_or(String::from("12"))
+            .parse()
+            .expect("Cannot parse DEGREE env var as u32");
 
         let params: Option<Params<G1Affine>> = {
             let params_path = format!(
@@ -147,7 +156,10 @@ mod tests {
 
     #[test]
     fn bench_keccak_padding_multi_row_2_circuit_prover() {
-        let degree: u32 = var("DEGREE").unwrap_or("12").parse()
+        let degree: u32 = var("DEGREE")
+            .unwrap_or(String::from("12"))
+            .parse()
+            .expect("Cannot parse DEGREE env var as u32");
 
         let params: Option<Params<G1Affine>> = {
             let params_path = format!(

--- a/circuit-benchmarks/src/keccak_padding_bench.rs
+++ b/circuit-benchmarks/src/keccak_padding_bench.rs
@@ -97,10 +97,10 @@ mod tests {
             .expect("Cannot parse DEGREE env var as u32");
 
         let params: Option<Params<G1Affine>> = {
-            let params_path = format!(
-                "/home/ubuntu/works/degree/references/data/params-{}",
-                degree
-            );
+            let params_path: String = var("PARAMS_PATH")
+                .unwrap_or(String::from(format!("./params-{}", degree)))
+                .parse()
+                .expect("Cannot parse PARAMS_PATH env var");
             File::open(&params_path)
                 .and_then(|fs| Params::read::<_>(&mut BufReader::new(fs)))
                 .ok()
@@ -119,14 +119,15 @@ mod tests {
             .expect("Cannot parse DEGREE env var as u32");
 
         let params: Option<Params<G1Affine>> = {
-            let params_path = format!(
-                "/home/ubuntu/works/degree/references/data/params-{}",
-                degree
-            );
+            let params_path: String = var("PARAMS_PATH")
+                .unwrap_or(String::from(format!("./params-{}", degree)))
+                .parse()
+                .expect("Cannot parse PARAMS_PATH env var");
             File::open(&params_path)
                 .and_then(|fs| Params::read::<_>(&mut BufReader::new(fs)))
                 .ok()
         };
+
         println!("type2:");
         let empty_circuit = KeccakMultiGadgetPaddingCircuit::<Fr>::default();
         bench_circuit(empty_circuit, params, degree);
@@ -140,10 +141,10 @@ mod tests {
             .expect("Cannot parse DEGREE env var as u32");
 
         let params: Option<Params<G1Affine>> = {
-            let params_path = format!(
-                "/home/ubuntu/works/degree/references/data/params-{}",
-                degree
-            );
+            let params_path: String = var("PARAMS_PATH")
+                .unwrap_or(String::from(format!("./params-{}", degree)))
+                .parse()
+                .expect("Cannot parse PARAMS_PATH env var");
             File::open(&params_path)
                 .and_then(|fs| Params::read::<_>(&mut BufReader::new(fs)))
                 .ok()
@@ -162,10 +163,10 @@ mod tests {
             .expect("Cannot parse DEGREE env var as u32");
 
         let params: Option<Params<G1Affine>> = {
-            let params_path = format!(
-                "/home/ubuntu/works/degree/references/data/params-{}",
-                degree
-            );
+            let params_path: String = var("PARAMS_PATH")
+                .unwrap_or(String::from(format!("./params-{}", degree)))
+                .parse()
+                .expect("Cannot parse PARAMS_PATH env var");
             File::open(&params_path)
                 .and_then(|fs| Params::read::<_>(&mut BufReader::new(fs)))
                 .ok()

--- a/circuit-benchmarks/src/lib.rs
+++ b/circuit-benchmarks/src/lib.rs
@@ -27,3 +27,7 @@ pub mod packed_keccak;
 #[cfg(test)]
 #[cfg(feature = "benches")]
 pub mod packed_multi_keccak;
+
+#[cfg(test)]
+#[cfg(feature = "benches")]
+pub mod keccak_padding_bench;

--- a/zkevm-circuits/src/keccak_circuit.rs
+++ b/zkevm-circuits/src/keccak_circuit.rs
@@ -23,3 +23,6 @@ pub mod keccak_padding_multi_gadgets;
 
 /// Keccak util for cell arrangement
 pub mod keccak_utils;
+
+/// Keccak full functionaility with padding bit version
+pub mod keccak_complete_bit;

--- a/zkevm-circuits/src/keccak_circuit.rs
+++ b/zkevm-circuits/src/keccak_circuit.rs
@@ -25,4 +25,4 @@ pub mod keccak_padding_multi_gadgets;
 pub mod keccak_utils;
 
 /// Keccak full functionaility with padding bit version
-pub mod keccak_complete_bit;
+pub mod keccak_complete_bit_2;

--- a/zkevm-circuits/src/keccak_circuit.rs
+++ b/zkevm-circuits/src/keccak_circuit.rs
@@ -15,6 +15,9 @@ pub mod keccak_padding;
 /// Keccak padding in multi rows
 pub mod keccak_padding_multirows;
 
+/// Keccak padding in multi rows mode 2
+pub mod keccak_padding_multirows_2;
+
 /// Keccak padding in multi gadgets
 pub mod keccak_padding_multi_gadgets;
 

--- a/zkevm-circuits/src/keccak_circuit.rs
+++ b/zkevm-circuits/src/keccak_circuit.rs
@@ -15,5 +15,8 @@ pub mod keccak_padding;
 /// Keccak padding in multi rows
 pub mod keccak_padding_multirows;
 
+/// Keccak padding in multi gadgets
+pub mod keccak_padding_multi_gadgets;
+
 /// Keccak util for cell arrangement
 pub mod keccak_utils;

--- a/zkevm-circuits/src/keccak_circuit.rs
+++ b/zkevm-circuits/src/keccak_circuit.rs
@@ -9,5 +9,11 @@ pub mod keccak_packed;
 /// Keccak packed multi
 pub mod keccak_packed_multi;
 
-/// Keccak packed multi
+/// Keccak padding circuit
 pub mod keccak_padding;
+
+/// Keccak padding in multi rows
+pub mod keccak_padding_multirows;
+
+/// Keccak util for cell arrangement
+pub mod keccak_utils;

--- a/zkevm-circuits/src/keccak_circuit.rs
+++ b/zkevm-circuits/src/keccak_circuit.rs
@@ -8,3 +8,6 @@ pub mod keccak_packed;
 
 /// Keccak packed multi
 pub mod keccak_packed_multi;
+
+/// Keccak packed multi
+pub mod keccak_padding;

--- a/zkevm-circuits/src/keccak_circuit/keccak_bit.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_bit.rs
@@ -887,11 +887,12 @@ mod tests {
         let r = KeccakBitCircuit::r();
         let inputs = multi_keccak(
             vec![
-                // vec![],
+                vec![],
+                (0u8..1).collect::<Vec<_>>(),
                 (1u8..2).collect::<Vec<_>>(),
-                /* (0u8..135).collect::<Vec<_>>(),
-                 * (0u8..136).collect::<Vec<_>>(),
-                 * (0u8..200).collect::<Vec<_>>(), */
+                (0u8..135).collect::<Vec<_>>(),
+                (0u8..136).collect::<Vec<_>>(),
+                (0u8..200).collect::<Vec<_>>(),
             ],
             r,
         );

--- a/zkevm-circuits/src/keccak_circuit/keccak_bit.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_bit.rs
@@ -88,18 +88,18 @@ pub(crate) struct KeccakRow<F> {
 /// KeccakBitConfig
 #[derive(Clone, Debug)]
 pub struct KeccakBitConfig<F> {
-    q_enable: Selector,
-    q_first: Selector,
-    q_round: Column<Fixed>,
-    q_absorb: Column<Fixed>,
-    q_end: Column<Advice>,
-    hash_rlc: Column<Advice>,
-    s_bits: [Column<Advice>; KECCAK_WIDTH],
-    c_bits: [Column<Advice>; C_WIDTH],
-    a_bits: [Column<Advice>; ABSORB_WIDTH_PER_ROW],
-    iota_bits: [Column<Fixed>; IOTA_ROUND_BIT_POS.len()],
-    c_table: Vec<TableColumn>,
-    _marker: PhantomData<F>,
+    pub(crate) q_enable: Selector,
+    pub(crate) q_first: Selector,
+    pub(crate) q_round: Column<Fixed>,
+    pub(crate) q_absorb: Column<Fixed>,
+    pub(crate) q_end: Column<Advice>,
+    pub(crate) hash_rlc: Column<Advice>,
+    pub(crate) s_bits: [Column<Advice>; KECCAK_WIDTH],
+    pub(crate) c_bits: [Column<Advice>; C_WIDTH],
+    pub(crate) a_bits: [Column<Advice>; ABSORB_WIDTH_PER_ROW],
+    pub(crate) iota_bits: [Column<Fixed>; IOTA_ROUND_BIT_POS.len()],
+    pub(crate) c_table: Vec<TableColumn>,
+    pub(crate) _marker: PhantomData<F>,
 }
 
 /// KeccakBitCircuit

--- a/zkevm-circuits/src/keccak_circuit/keccak_complete_bit.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_complete_bit.rs
@@ -1,0 +1,211 @@
+/*
+INCORRECT IMPLEMENTATION, DO NOT USE!!!
+*/
+
+use eth_types::Field;
+use halo2_proofs::{
+    circuit::{Layouter, SimpleFloorPlanner},
+    plonk::{Circuit, ConstraintSystem, Error},
+};
+use std::{env::var, marker::PhantomData};
+
+use super::{
+    keccak_bit::{KeccakBitConfig, KeccakRow},
+    keccak_padding_multirows_2::{KeccakPaddingBlock, KeccakPaddingConfig},
+};
+
+fn get_degree() -> usize {
+    var("DEGREE")
+        .unwrap_or_else(|_| "8".to_string())
+        .parse()
+        .expect("Cannot parse DEGREE env var as usize")
+}
+
+/// KeccakBitConfig
+#[derive(Clone, Debug)]
+pub struct KeccakCompleteBitConfig<F> {
+    keccak_config: KeccakBitConfig<F>,
+    padding_config: KeccakPaddingConfig<F>,
+}
+
+/// KeccakBitCircuit
+#[derive(Default)]
+pub struct KeccakCompleteBitCircuit<F: Field> {
+    inputs: Vec<KeccakRow<F>>,
+    size: usize,
+    _marker: PhantomData<F>,
+}
+
+impl<F: Field> KeccakCompleteBitCircuit<F> {
+    fn r() -> F {
+        F::from(123456)
+    }
+}
+
+impl<F: Field> Circuit<F> for KeccakCompleteBitCircuit<F> {
+    type Config = KeccakCompleteBitConfig<F>;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        KeccakCompleteBitConfig::configure(meta, KeccakCompleteBitCircuit::r())
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        config.load(&mut layouter)?;
+        config.assign(
+            layouter,
+            self.size,
+            &self.inputs,
+            KeccakCompleteBitCircuit::r(),
+        )?;
+        Ok(())
+    }
+}
+
+impl<F: Field> KeccakCompleteBitConfig<F> {
+    pub(crate) fn configure(meta: &mut ConstraintSystem<F>, r: F) -> Self {
+        KeccakCompleteBitConfig {
+            keccak_config: KeccakBitConfig::configure(meta, r),
+            padding_config: KeccakPaddingConfig::configure(meta),
+        }
+    }
+
+    fn assign(
+        &self,
+        mut layouter: impl Layouter<F>,
+        _size: usize,
+        witness: &[KeccakRow<F>],
+        r: F,
+    ) -> Result<(), Error> {
+        layouter.assign_region(
+            || "assign keccak rounds with padding",
+            |mut region| {
+                for (offset, keccak_row) in witness.iter().enumerate() {
+                    self.keccak_config.set_row(
+                        &mut region,
+                        offset,
+                        keccak_row.q_end,
+                        keccak_row.hash_rlc,
+                        keccak_row.s_bits,
+                        keccak_row.c_bits,
+                        keccak_row.a_bits,
+                    )?;
+                }
+
+                let keccak_padding_block: &KeccakPaddingBlock<F> = &witness.try_into().unwrap();
+                // for row in &keccak_padding_block.block_rows {
+                //   println!("row: {:?}", row);
+                // }
+                // println!("keccak_padding_block is {:?}", keccak_padding_block);
+                self.padding_config.set_region(
+                    &mut region,
+                    witness.len() - 25,
+                    keccak_padding_block,
+                    r,
+                )?;
+                Ok(())
+            },
+        )
+    }
+
+    pub(crate) fn load(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
+        self.keccak_config.load(layouter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::marker::PhantomData;
+
+    use crate::keccak_circuit::keccak_bit::{keccak, ABSORB_WIDTH_PER_ROW, C_WIDTH, KECCAK_WIDTH};
+
+    use super::*;
+    use halo2_proofs::{dev::MockProver, pairing::bn256::Fr};
+
+    fn verify<F: Field>(k: u32, inputs: Vec<KeccakRow<F>>, success: bool) {
+        let circuit = KeccakCompleteBitCircuit::<F> {
+            inputs,
+            size: 2usize.pow(k),
+            _marker: PhantomData,
+        };
+
+        let prover = MockProver::<F>::run(k, &circuit, vec![]).unwrap();
+        let err = prover.verify();
+        let print_failures = true;
+        if err.is_err() && print_failures {
+            for e in err.err().iter() {
+                for s in e.iter() {
+                    println!("{}", s);
+                }
+            }
+        }
+        let err = prover.verify();
+        assert_eq!(err.is_ok(), success);
+    }
+
+    fn complete_keccak<F: Field>(bytes: Vec<u8>, r: F) -> Vec<KeccakRow<F>> {
+        // Dummy first row so that the initial data is absorbed
+        // The initial data doesn't really matter, `q_end` just needs to be enabled.
+        let mut rows: Vec<KeccakRow<F>> = vec![KeccakRow {
+            s_bits: [0u8; KECCAK_WIDTH],
+            c_bits: [0u8; C_WIDTH],
+            a_bits: [0u8; ABSORB_WIDTH_PER_ROW],
+            q_end: 1u64,
+            hash_rlc: F::zero(),
+            input_len: 0u64,
+            input_rlc: F::zero(),
+        }];
+
+        // Actual keccaks
+        keccak(&mut rows, bytes, r);
+        rows
+    }
+
+    #[test]
+    fn complete_bit_keccak_nil() {
+        let k = 8;
+        let r = KeccakCompleteBitCircuit::r();
+        let inputs = complete_keccak(vec![], r);
+        verify::<Fr>(k, inputs, true);
+    }
+
+    #[test]
+    fn complete_bit_keccak_0() {
+        let k = 8;
+        let r = KeccakCompleteBitCircuit::r();
+        let inputs = complete_keccak(vec![0], r);
+        verify::<Fr>(k, inputs, true);
+    }
+
+    #[test]
+    fn complete_bit_keccak_135() {
+        let k = 8;
+        let r = KeccakCompleteBitCircuit::r();
+        let inputs = complete_keccak((0..135).collect(), r);
+        verify::<Fr>(k, inputs, true);
+    }
+
+    #[test]
+    fn complete_bit_keccak_136() {
+        let k = 8;
+        let r = KeccakCompleteBitCircuit::r();
+        let inputs = complete_keccak((0..136).collect(), r);
+        verify::<Fr>(k, inputs, true);
+    }
+
+    #[test]
+    fn complete_bit_keccak_211() {
+        let k = 8;
+        let r = KeccakCompleteBitCircuit::r();
+        let inputs = complete_keccak((0..211).collect(), r);
+        verify::<Fr>(k, inputs, true);
+    }
+}

--- a/zkevm-circuits/src/keccak_circuit/keccak_complete_bit_2.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_complete_bit_2.rs
@@ -1,0 +1,210 @@
+use eth_types::Field;
+use halo2_proofs::{
+    circuit::{Layouter, SimpleFloorPlanner},
+    plonk::{Circuit, ConstraintSystem, Error},
+};
+use std::{env::var, marker::PhantomData};
+
+use super::{
+    keccak_bit::{KeccakBitConfig, KeccakRow},
+    keccak_padding_multirows_2::{KeccakPaddingBlock, KeccakPaddingConfig},
+};
+
+fn get_degree() -> usize {
+    var("DEGREE")
+        .unwrap_or_else(|_| "8".to_string())
+        .parse()
+        .expect("Cannot parse DEGREE env var as usize")
+}
+
+/// KeccakBitConfig
+#[derive(Clone, Debug)]
+pub struct KeccakCompleteBitConfig<F> {
+    keccak_config: KeccakBitConfig<F>,
+    padding_config: KeccakPaddingConfig<F>,
+}
+
+/// KeccakBitCircuit
+#[derive(Default)]
+pub struct KeccakCompleteBitCircuit<F: Field> {
+    inputs: Vec<KeccakRow<F>>,
+    size: usize,
+    _marker: PhantomData<F>,
+}
+
+impl<F: Field> KeccakCompleteBitCircuit<F> {
+    fn r() -> F {
+        F::from(123456)
+    }
+}
+
+impl<F: Field> Circuit<F> for KeccakCompleteBitCircuit<F> {
+    type Config = KeccakCompleteBitConfig<F>;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        KeccakCompleteBitConfig::configure(meta, KeccakCompleteBitCircuit::r())
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        config.load(&mut layouter)?;
+        config.assign(
+            layouter,
+            self.size,
+            &self.inputs,
+            KeccakCompleteBitCircuit::r(),
+        )?;
+        Ok(())
+    }
+}
+
+impl<F: Field> KeccakCompleteBitConfig<F> {
+    pub(crate) fn configure(meta: &mut ConstraintSystem<F>, r: F) -> Self {
+        let keccak_config = KeccakBitConfig::configure(meta, r);
+        let padding_config = KeccakPaddingConfig::configure(meta, Some(keccak_config.a_bits));
+
+        KeccakCompleteBitConfig {
+            keccak_config: keccak_config,
+            padding_config: padding_config,
+        }
+    }
+
+    fn assign(
+        &self,
+        mut layouter: impl Layouter<F>,
+        _size: usize,
+        witness: &[KeccakRow<F>],
+        r: F,
+    ) -> Result<(), Error> {
+        layouter.assign_region(
+            || "assign keccak rounds with padding",
+            |mut region| {
+                for (offset, keccak_row) in witness.iter().enumerate() {
+                    self.keccak_config.set_row(
+                        &mut region,
+                        offset,
+                        keccak_row.q_end,
+                        keccak_row.hash_rlc,
+                        keccak_row.s_bits,
+                        keccak_row.c_bits,
+                        keccak_row.a_bits,
+                    )?;
+                    println!("offset {}, q_end {}", offset, keccak_row.q_end);
+                }
+
+                let keccak_padding_block: &KeccakPaddingBlock<F> = &witness.try_into().unwrap();
+                // for row in &keccak_padding_block.block_rows {
+                //     println!("row: {:?}", row);
+                // }
+                self.padding_config.set_region(
+                    &mut region,
+                    witness.len() - 25 - 1, // to align the data with padding
+                    keccak_padding_block,
+                    r,
+                )?;
+                Ok(())
+            },
+        )
+    }
+
+    pub(crate) fn load(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
+        self.keccak_config.load(layouter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::marker::PhantomData;
+
+    use crate::keccak_circuit::keccak_bit::{keccak, ABSORB_WIDTH_PER_ROW, C_WIDTH, KECCAK_WIDTH};
+
+    use super::*;
+    use halo2_proofs::{dev::MockProver, pairing::bn256::Fr};
+
+    fn verify<F: Field>(k: u32, inputs: Vec<KeccakRow<F>>, success: bool) {
+        let circuit = KeccakCompleteBitCircuit::<F> {
+            inputs,
+            size: 2usize.pow(k),
+            _marker: PhantomData,
+        };
+
+        let prover = MockProver::<F>::run(k, &circuit, vec![]).unwrap();
+        let err = prover.verify();
+        let print_failures = true;
+        if err.is_err() && print_failures {
+            for e in err.err().iter() {
+                for s in e.iter() {
+                    println!("{}", s);
+                }
+            }
+        }
+        let err = prover.verify();
+        assert_eq!(err.is_ok(), success);
+    }
+
+    fn complete_keccak<F: Field>(bytes: Vec<u8>, r: F) -> Vec<KeccakRow<F>> {
+        // Dummy first row so that the initial data is absorbed
+        // The initial data doesn't really matter, `q_end` just needs to be enabled.
+        let mut rows: Vec<KeccakRow<F>> = vec![KeccakRow {
+            s_bits: [0u8; KECCAK_WIDTH],
+            c_bits: [0u8; C_WIDTH],
+            a_bits: [0u8; ABSORB_WIDTH_PER_ROW],
+            q_end: 1u64,
+            hash_rlc: F::zero(),
+            input_len: 0u64,
+            input_rlc: F::zero(),
+        }];
+
+        // Actual keccaks
+        keccak(&mut rows, bytes, r);
+        rows
+    }
+
+    #[test]
+    fn complete_bit_keccak_nil() {
+        let k = 8;
+        let r = KeccakCompleteBitCircuit::r();
+        let inputs = complete_keccak(vec![], r);
+        verify::<Fr>(k, inputs, true);
+    }
+
+    #[test]
+    fn complete_bit_keccak_0() {
+        let k = 8;
+        let r = KeccakCompleteBitCircuit::r();
+        let inputs = complete_keccak(vec![0], r);
+        verify::<Fr>(k, inputs, true);
+    }
+
+    #[test]
+    fn complete_bit_keccak_135() {
+        let k = 8;
+        let r = KeccakCompleteBitCircuit::r();
+        let inputs = complete_keccak((0..135).collect(), r);
+        verify::<Fr>(k, inputs, true);
+    }
+
+    #[test]
+    fn complete_bit_keccak_136() {
+        let k = 8;
+        let r = KeccakCompleteBitCircuit::r();
+        let inputs = complete_keccak((0..136).collect(), r);
+        verify::<Fr>(k, inputs, true);
+    }
+
+    #[test]
+    fn complete_bit_keccak_211() {
+        let k = 8;
+        let r = KeccakCompleteBitCircuit::r();
+        let inputs = complete_keccak((0..211).collect(), r);
+        verify::<Fr>(k, inputs, true);
+    }
+}

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding.rs
@@ -60,11 +60,7 @@ impl<F: Field> Circuit<F> for KeccakPaddingCircuit<F> {
         KeccakPaddingConfig::configure(meta)
     }
 
-    fn synthesize(
-        &self,
-        config: Self::Config,
-        mut layouter: impl Layouter<F>,
-    ) -> Result<(), Error> {
+    fn synthesize(&self, config: Self::Config, layouter: impl Layouter<F>) -> Result<(), Error> {
         config.assign(
             layouter,
             self.size,

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding.rs
@@ -1,0 +1,423 @@
+use crate::{evm_circuit::util::constraint_builder::BaseConstraintBuilder, util::Expr};
+use eth_types::Field;
+use gadgets::util::not;
+use halo2_proofs::{
+    circuit::{Layouter, Region, SimpleFloorPlanner},
+    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Selector},
+    poly::Rotation,
+};
+use std::{env::var, marker::PhantomData, vec};
+
+const KECCAK_WIDTH: usize = 5 * 5 * 64;
+const KECCAK_RATE: usize = 1088;
+const KECCAK_RATE_IN_BYTES: usize = KECCAK_RATE / 8;
+
+fn get_degree() -> usize {
+    var("DEGREE")
+        .unwrap_or_else(|_| "8".to_string())
+        .parse()
+        .expect("Cannot parse DEGREE env var as usize")
+}
+
+/// KeccakConfig
+#[derive(Clone, Debug)]
+pub struct KeccakPaddingConfig<F> {
+    q_enable: Selector,
+    q_end: Column<Advice>,
+    d_bits: [Column<Advice>; KECCAK_WIDTH],
+    d_lens: [Column<Advice>; KECCAK_RATE_IN_BYTES],
+    d_rlcs: [Column<Advice>; KECCAK_RATE_IN_BYTES],
+    s_flags: [Column<Advice>; KECCAK_RATE_IN_BYTES],
+    randomness: Column<Advice>,
+
+    _marker: PhantomData<F>,
+}
+
+pub(crate) struct KeccakPaddingRow<F: Field> {
+    pub(crate) q_end: u64,
+    pub(crate) d_bits: [u8; KECCAK_WIDTH],
+    pub(crate) d_lens: [u32; KECCAK_RATE_IN_BYTES],
+    pub(crate) d_rlcs: [F; KECCAK_RATE_IN_BYTES],
+    pub(crate) s_flags: [bool; KECCAK_RATE_IN_BYTES],
+}
+
+/// KeccakBitircuit
+#[derive(Default)]
+pub struct KeccakPaddingCircuit<F: Field> {
+    inputs: Vec<KeccakPaddingRow<F>>,
+    size: usize,
+    _marker: PhantomData<F>,
+}
+
+impl<F: Field> KeccakPaddingCircuit<F> {
+    fn r() -> F {
+        F::from(123456)
+    }
+}
+
+impl<F: Field> Circuit<F> for KeccakPaddingCircuit<F> {
+    type Config = KeccakPaddingConfig<F>;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        KeccakPaddingConfig::configure(meta)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        config.assign(
+            layouter,
+            self.size,
+            &self.inputs[0],
+            KeccakPaddingCircuit::r(),
+        )?;
+        Ok(())
+    }
+}
+
+impl<F: Field> KeccakPaddingConfig<F> {
+    pub(crate) fn configure(meta: &mut ConstraintSystem<F>) -> Self {
+        let q_enable = meta.selector();
+        let q_end = meta.advice_column();
+        let d_bits = [(); KECCAK_WIDTH].map(|_| meta.advice_column());
+        let d_lens = [(); KECCAK_RATE_IN_BYTES].map(|_| meta.advice_column());
+        let d_rlcs = [(); KECCAK_RATE_IN_BYTES].map(|_| meta.advice_column());
+        let s_flags = [(); KECCAK_RATE_IN_BYTES].map(|_| meta.advice_column());
+        let randomness = meta.advice_column();
+
+        meta.create_gate("boolean checks", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+            for s_flag in s_flags {
+                let s = meta.query_advice(s_flag, Rotation::cur());
+                cb.require_boolean("boolean state bit", s);
+            }
+
+            for i in 1..s_flags.len() {
+                let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                let s_i_1 = meta.query_advice(s_flags[i - 1], Rotation::cur());
+
+                cb.require_boolean("boolean state switch", s_i - s_i_1);
+            }
+
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        meta.create_gate("padding bit checks", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            let mut constraints = vec![];
+            for i in 1..s_flags.len() {
+                let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                let s_i_1 = meta.query_advice(s_flags[i - 1], Rotation::cur());
+                let d_bit_0 = meta.query_advice(d_bits[8 * i], Rotation::cur());
+                constraints.push(("1 || 0*", (s_i - s_i_1) * (d_bit_0 - 1u64.expr())));
+            }
+            let s_last = meta.query_advice(s_flags[s_flags.len() - 1], Rotation::cur());
+            let d_last = meta.query_advice(d_bits[KECCAK_RATE - 1], Rotation::cur());
+
+            constraints.push(("end with 1", s_last * (d_last - 1u64.expr())));
+
+            cb.add_constraints(constraints);
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        meta.create_gate("intermedium 0 checks", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            let mut sum_padding_bits = 0u64.expr();
+            for i in 0..s_flags.len() {
+                let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                sum_padding_bits = d_bits[i * 8..(i + 1) * 8]
+                    .iter()
+                    .map(|b| meta.query_advice(*b, Rotation::cur()))
+                    .fold(sum_padding_bits, |sum, b| sum + s_i.clone() * b);
+            }
+
+            cb.add_constraint("sum padding bits == 2", sum_padding_bits - 2u64.expr());
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        meta.create_gate("input len check", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            let mut constraints = vec![];
+            for i in 1..s_flags.len() {
+                let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                let len_i = meta.query_advice(d_lens[i], Rotation::cur());
+                let len_i_1 = meta.query_advice(d_lens[i - 1], Rotation::cur());
+                constraints.push(("len += !s_i", len_i - len_i_1 - not::expr(s_i)));
+            }
+
+            cb.add_constraints(constraints);
+
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        meta.create_gate("input rlc check", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            let mut constraints = vec![];
+            for i in 1..s_flags.len() {
+                let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                let rlc_i = meta.query_advice(d_rlcs[i], Rotation::cur());
+                let rlc_i_1 = meta.query_advice(d_rlcs[i - 1], Rotation::cur());
+                let r = meta.query_advice(randomness, Rotation::cur());
+                let input_byte_i = d_bits[i * 8..(i + 1) * 8]
+                    .iter()
+                    .map(|bit| meta.query_advice(*bit, Rotation::cur()))
+                    .fold(0u64.expr(), |v, b| v * 2u64.expr() + b);
+                constraints.push((
+                    "rlc[i] = rlc[i-1]*r if s == 0 else rlc[i]",
+                    rlc_i.clone()
+                        - (rlc_i.clone() * s_i.clone()
+                            + (rlc_i_1 * r + input_byte_i) * not::expr(s_i.clone())),
+                ));
+            }
+
+            cb.add_constraints(constraints);
+
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        meta.create_gate("input ending check", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            let s_last = meta.query_advice(s_flags[s_flags.len() - 1], Rotation::cur());
+            let q_end = meta.query_advice(q_end, Rotation::cur());
+
+            cb.require_equal("s_last == q_end", s_last, q_end);
+
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        KeccakPaddingConfig {
+            q_enable,
+            q_end,
+            d_bits,
+            d_lens,
+            d_rlcs,
+            s_flags,
+            randomness,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn assign(
+        &self,
+        mut layouter: impl Layouter<F>,
+        _size: usize,
+        keccak_row: &KeccakPaddingRow<F>,
+        randomness: F,
+    ) -> Result<(), Error> {
+        layouter.assign_region(
+            || "assign keccak rounds",
+            |mut region| {
+                self.set_row(
+                    &mut region,
+                    0,
+                    keccak_row.q_end,
+                    keccak_row.d_bits,
+                    keccak_row.d_lens,
+                    keccak_row.d_rlcs,
+                    keccak_row.s_flags,
+                    randomness,
+                )?;
+                Ok(())
+            },
+        )
+    }
+
+    fn set_row(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        q_end: u64,
+        d_bits: [u8; KECCAK_WIDTH],
+        d_lens: [u32; KECCAK_RATE_IN_BYTES],
+        d_rlcs: [F; KECCAK_RATE_IN_BYTES],
+        s_flags: [bool; KECCAK_RATE_IN_BYTES],
+        randomness: F,
+    ) -> Result<(), Error> {
+        self.q_enable.enable(region, offset)?;
+
+        // Input bits w/ padding
+        for (idx, (bit, column)) in d_bits.iter().zip(self.d_bits.iter()).enumerate() {
+            region.assign_advice(
+                || format!("assign input data bit {} {}", idx, offset),
+                *column,
+                offset,
+                || Ok(F::from(*bit as u64)),
+            )?;
+        }
+
+        for (idx, (s_flag, column)) in s_flags.iter().zip(self.s_flags.iter()).enumerate() {
+            region.assign_advice(
+                || format!("assign input data select flag {} {}", idx, offset),
+                *column,
+                offset,
+                || Ok(F::from(*s_flag as u64)),
+            )?;
+        }
+
+        for (idx, (d_len, column)) in d_lens.iter().zip(self.d_lens.iter()).enumerate() {
+            region.assign_advice(
+                || format!("assign input data len {} {}", idx, offset),
+                *column,
+                offset,
+                || Ok(F::from(*d_len as u64)),
+            )?;
+        }
+
+        for (idx, (d_rlc, column)) in d_rlcs.iter().zip(self.d_rlcs.iter()).enumerate() {
+            region.assign_advice(
+                || format!("assign input data rlc {} {}", idx, offset),
+                *column,
+                offset,
+                || Ok(*d_rlc),
+            )?;
+        }
+
+        region.assign_advice(
+            || format!("assign q_end{}", offset),
+            self.q_end,
+            offset,
+            || Ok(F::from(q_end)),
+        )?;
+
+        region.assign_advice(
+            || format!("assign q_end{}", offset),
+            self.randomness,
+            offset,
+            || Ok(randomness),
+        )?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::marker::PhantomData;
+
+    use super::*;
+    use halo2_proofs::{dev::MockProver, pairing::bn256::Fr};
+
+    fn verify<F: Field>(k: u32, inputs: Vec<KeccakPaddingRow<F>>, success: bool) {
+        let circuit = KeccakPaddingCircuit::<F> {
+            inputs,
+            size: 2usize.pow(k),
+            _marker: PhantomData,
+        };
+
+        let prover = MockProver::<F>::run(K, &circuit, vec![]).unwrap();
+        let err = prover.verify();
+        let print_failures = true;
+        if err.is_err() && print_failures {
+            for e in err.err().iter() {
+                for s in e.iter() {
+                    println!("{}", s);
+                }
+            }
+        }
+        let err = prover.verify();
+        assert_eq!(err.is_ok(), success);
+    }
+
+    fn generate_padding<F: Field>(data_len: u32) -> KeccakPaddingRow<F> {
+        let mut output = KeccakPaddingRow::<F> {
+            d_bits: [0; KECCAK_WIDTH],
+            d_lens: [0; KECCAK_RATE_IN_BYTES],
+            d_rlcs: [F::from(0u64); KECCAK_RATE_IN_BYTES],
+            s_flags: [false; KECCAK_RATE_IN_BYTES],
+            q_end: 1u64,
+        };
+        let s_bits_len = data_len as usize * 8;
+
+        let data_len_offset = data_len % KECCAK_RATE_IN_BYTES as u32;
+        let data_len_base = (data_len / KECCAK_RATE_IN_BYTES as u32) * KECCAK_RATE_IN_BYTES as u32;
+
+        output.s_flags[0] = data_len_offset == 0u32;
+        output.d_lens[0] = data_len_base + !output.s_flags[0] as u32;
+
+        for i in 1 as usize..KECCAK_RATE_IN_BYTES {
+            output.s_flags[i] = {
+                if (i as u32) < data_len_offset {
+                    false
+                } else {
+                    true
+                }
+            };
+            output.d_lens[i] = output.d_lens[i - 1] + !output.s_flags[i] as u32;
+        }
+
+        for i in s_bits_len..KECCAK_RATE {
+            output.d_bits[i] = 0u8;
+        }
+        output.d_bits[s_bits_len] = 1;
+
+        output.d_bits[KECCAK_RATE - 1] = 1;
+        println!("{:?}", output.s_flags);
+        println!("{:?}", output.d_bits);
+        println!("{:?}", output.d_lens);
+        output
+    }
+
+    static K: u32 = 8;
+
+    #[test]
+    fn bit_keccak_simple() {
+        let input = generate_padding::<Fr>(0);
+        verify::<Fr>(K, vec![input], true);
+    }
+
+    #[test]
+    fn bit_keccak_len_1() {
+        let input = generate_padding::<Fr>(1);
+        verify::<Fr>(K, vec![input], true);
+    }
+
+    #[test]
+    fn bit_keccak_len_135() {
+        let input = generate_padding::<Fr>(135);
+        verify::<Fr>(K, vec![input], true);
+    }
+
+    #[test]
+    fn bit_keccak_invalid_padding_begin() {
+        // first bit is 0
+        let mut input = generate_padding::<Fr>(11);
+        input.d_bits[11 * 8] = 0u8;
+        verify::<Fr>(K, vec![input], false);
+    }
+
+    #[test]
+    fn bit_keccak_invalid_padding_end() {
+        // last bit is 0
+        let mut input = generate_padding::<Fr>(73);
+        input.d_bits[KECCAK_RATE - 1] = 0u8;
+        verify::<Fr>(K, vec![input], false);
+    }
+
+    #[test]
+    fn bit_keccak_invalid_padding_mid() {
+        // some 1 in padding
+        let mut input = generate_padding::<Fr>(123);
+        input.d_bits[KECCAK_RATE - 2] = 1u8;
+        verify::<Fr>(K, vec![input], false);
+    }
+
+    #[test]
+    fn bit_keccak_invalid_padding() {
+        // wrong len
+        let mut input = generate_padding::<Fr>(123);
+        input.d_lens[124] = 124;
+        verify::<Fr>(K, vec![input], false);
+    }
+}

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding.rs
@@ -116,8 +116,6 @@ impl<F: Field> KeccakPaddingConfig<F> {
                 let s_i = meta.query_advice(s_flags[i], Rotation::cur());
                 let s_i_sub1 = meta.query_advice(s_flags[i - 1], Rotation::cur());
                 let d_bit_0 = meta.query_advice(d_bits[8 * i], Rotation::cur());
-                // constraints.push(("begin with 1", (s_i - s_i_sub1) * (d_bit_0 -
-                // 1u64.expr())));
                 let s_padding_start = s_i - s_i_sub1;
                 cb.condition(s_padding_start, |cb| {
                     cb.require_equal("start with 1", d_bit_0, 1u64.expr());

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding.rs
@@ -172,6 +172,7 @@ impl<F: Field> KeccakPaddingConfig<F> {
                 let r = meta.query_advice(randomness, Rotation::cur());
                 let input_byte_i = d_bits[i * 8..(i + 1) * 8]
                     .iter()
+                    .rev()
                     .map(|bit| meta.query_advice(*bit, Rotation::cur()))
                     .fold(0u64.expr(), |v, b| v * 2u64.expr() + b);
                 cb.require_equal(
@@ -355,6 +356,7 @@ pub(crate) mod tests {
                 + F::from(
                     output.d_bits[0..8]
                         .iter()
+                        .rev()
                         .fold(0, |byte, bit| byte * 2 + bit) as u64,
                 )
         };

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding_multi_gadgets.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding_multi_gadgets.rs
@@ -19,7 +19,7 @@ const KECCAK_REGION_HEIGHT: usize = KECCAK_RATE / KECCAK_DATA_REGION_WIDTH;
 #[rustfmt::skip]
 /// KeccakMultiGadgetPaddingConfig
 /// The data field of circuit Layout is like this (without selectors),
-/// each row is a KeccakSubRowConfig with 64 bits data.
+/// each row is a KeccakSubRowConfig which has 64 bits data.
 /// 
 ///        +-----------+--------------+-----------+------------+----------+-----------+------------+
 /// 1st      prev_xxxx    d_bits[64]    d_lens[8]   s_flags[8]   d_rlcs[8]  curr_xxxx   randomness  
@@ -643,7 +643,6 @@ impl<F: Field> KeccakMultiGadgetPaddingConfig<F> {
                     offset,
                     || Ok(F::zero()),
                 )?;
-
                 let randomness = region.assign_advice(
                     || format!("assign randomness{}", offset),
                     self.first_row_config.config.randomness,
@@ -750,11 +749,14 @@ mod tests {
 
     fn generate_padding_sub_rows<F: Field>(data_len: u32) -> Vec<KeccakPaddingSubRow<F>> {
         let mut keccak_padding = KeccakPaddingRow::<F> {
+            q_end: 1u64,
+            acc_len: data_len,
+            acc_rlc: F::one(),
             d_bits: [0; KECCAK_WIDTH],
             d_lens: [0; KECCAK_RATE_IN_BYTES],
             d_rlcs: [F::from(0u64); KECCAK_RATE_IN_BYTES],
             s_flags: [false; KECCAK_RATE_IN_BYTES],
-            q_end: 1u64,
+            randomness: KeccakMultiGadgetPaddingCircuit::r(),
         };
 
         let data_len_offset = data_len % KECCAK_RATE_IN_BYTES as u32;

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding_multi_gadgets.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding_multi_gadgets.rs
@@ -1,0 +1,844 @@
+use crate::{evm_circuit::util::constraint_builder::BaseConstraintBuilder, util::Expr};
+use eth_types::Field;
+use gadgets::util::{not, select};
+use halo2_proofs::circuit::AssignedCell;
+use halo2_proofs::{
+    circuit::{Layouter, Region, SimpleFloorPlanner},
+    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Selector},
+    poly::Rotation,
+};
+use std::marker::PhantomData;
+
+const KECCAK_WIDTH: usize = 5 * 5 * 64;
+const KECCAK_RATE: usize = 1088;
+const KECCAK_RATE_IN_BYTES: usize = KECCAK_RATE / 8;
+
+const KECCAK_DATA_REGION_WIDTH: usize = 64;
+const KECCAK_REGION_HEIGHT: usize = KECCAK_RATE / KECCAK_DATA_REGION_WIDTH;
+
+#[rustfmt::skip]
+/// KeccakMultiGadgetPaddingConfig
+/// Circuit Layout is like this, each row is a KeccakSubRowConfig with 64 bits data.
+///        +-----------+-----------------+--------------+---------------+-------------+----------------+------------+
+/// 1st      prev_xxxx    d_bits[0..64]    d_lens[0..8]   s_flags[0..8]   d_rlcs[0..8]  curr_last_xxxx   randomness  
+///        +-----------+-----------------+--------------+---------------+-------------+----------------+------------+
+///                                                                                             |            |
+///            +--------------------------------------------------------------------------------+            |
+///            |                                                                                             |
+///        +-----------+-----------------+--------------+---------------+-------------+----------------+------------+
+/// 2nd      prev_xxxx    d_bits[0..64]    d_lens[0..8]   s_flags[0..8]   d_rlcs[0..8]  curr_last_xxxx   randomness   
+///  .     +-----------+-----------------+--------------+---------------+-------------+----------------+------------+
+///  .                                                                                          |            |
+/// (middle)   +--------------------------------------------------------------------------------+            |
+///  .         |                                                                                             |
+///  .     +-----------+-----------------+--------------+---------------+-------------+----------------+------------+
+/// 15th     prev_xxxx    d_bits[0..64]    d_lens[0..8]   s_flags[0..8]   d_rlcs[0..8]  curr_last_xxxx   randomness  
+///  .     +-----------+-----------------+--------------+---------------+-------------+----------------+------------+
+///                                                                                             |            |
+///            +--------------------------------------------------------------------------------+            |
+///            |                                                                                             |
+///        +-----------+-----------------+--------------+---------------+-------------+----------------+------------+
+/// last     prev_xxxx    d_bits[0..64]    d_lens[0..8]   s_flags[0..8]   d_rlcs[0..8]  curr_last_xxxx   randomness  
+/// (16th) +-----------+-----------------+--------------+---------------+-------------+----------------+------------+
+#[derive(Clone, Debug)]
+pub struct KeccakMultiGadgetPaddingConfig<F> {
+    q_enable: Selector,
+    first_row_config: KeccakSubRowConfig<F>,
+    middle_row_config: KeccakSubRowConfig<F>,
+    last_row_config: KeccakSubRowConfig<F>,
+    randomness: Column<Advice>,
+    _marker: PhantomData<F>,
+}
+
+pub(crate) struct KeccakPaddingSubRow<F: Field> {
+    pub(crate) q_end: u64,
+    prev_len: u32,
+    prev_rlc: F,
+    prev_s_flag: bool,
+    prev_padding_sum: u32,
+    curr_len: u32,
+    curr_rlc: F,
+    curr_s_flag: bool,
+    curr_padding_sum: u32,
+    randomness: F,
+    pub(crate) d_bits: [u8; KECCAK_DATA_REGION_WIDTH],
+    pub(crate) d_lens: [u32; KECCAK_DATA_REGION_WIDTH / 8],
+    pub(crate) d_rlcs: [F; KECCAK_DATA_REGION_WIDTH / 8],
+    pub(crate) s_flags: [bool; KECCAK_DATA_REGION_WIDTH / 8],
+}
+
+///KeccakSubRowConfig
+#[derive(Clone, Debug)]
+pub struct KeccakSubRowConfig<F> {
+    q_enable: Selector,
+    q_end: Column<Advice>,
+    prev_len: Column<Advice>,
+    prev_rlc: Column<Advice>,
+    prev_s_flag: Column<Advice>,
+    prev_padding_sum: Column<Advice>,
+    curr_len: Column<Advice>,
+    curr_rlc: Column<Advice>,
+    curr_s_flag: Column<Advice>,
+    curr_padding_sum: Column<Advice>,
+    d_bits: [Column<Advice>; KECCAK_DATA_REGION_WIDTH],
+    d_lens: [Column<Advice>; KECCAK_DATA_REGION_WIDTH / 8],
+    d_rlcs: [Column<Advice>; KECCAK_DATA_REGION_WIDTH / 8],
+    s_flags: [Column<Advice>; KECCAK_DATA_REGION_WIDTH / 8],
+    randomness: Column<Advice>,
+
+    _marker: PhantomData<F>,
+}
+
+impl<F: Field> KeccakSubRowConfig<F> {
+    fn configure(
+        meta: &mut ConstraintSystem<F>,
+        is_first_row: bool,
+        is_last_row: bool,
+    ) -> KeccakSubRowConfig<F> {
+        let q_enable = meta.selector();
+        let q_end = meta.advice_column();
+        let prev_len = meta.advice_column();
+        let prev_rlc = meta.advice_column();
+        let prev_s_flag = meta.advice_column();
+        let prev_padding_sum = meta.advice_column();
+        let curr_len = meta.advice_column();
+        let curr_rlc = meta.advice_column();
+        let curr_s_flag = meta.advice_column();
+        let curr_padding_sum = meta.advice_column();
+        let d_bits = [(); KECCAK_DATA_REGION_WIDTH].map(|_| meta.advice_column());
+        let d_lens = [(); KECCAK_DATA_REGION_WIDTH / 8].map(|_| meta.advice_column());
+        let d_rlcs = [(); KECCAK_DATA_REGION_WIDTH / 8].map(|_| meta.advice_column());
+        let s_flags = [(); KECCAK_DATA_REGION_WIDTH / 8].map(|_| meta.advice_column());
+        let randomness = meta.advice_column();
+
+        meta.enable_equality(prev_len);
+        meta.enable_equality(prev_rlc);
+        meta.enable_equality(prev_s_flag);
+        meta.enable_equality(prev_padding_sum);
+        meta.enable_equality(curr_len);
+        meta.enable_equality(curr_rlc);
+        meta.enable_equality(curr_s_flag);
+        meta.enable_equality(curr_padding_sum);
+
+        if is_first_row {
+            meta.create_gate("prev should be 0 for the 1st row", |meta| {
+                let mut cb = BaseConstraintBuilder::new(5);
+
+                // len & rlc are passed down by previous circuit, they are not necessarily 0.
+                cb.require_zero(
+                    "prev_s_flag == 0",
+                    meta.query_advice(prev_s_flag, Rotation::cur()),
+                );
+                cb.require_zero(
+                    "prev_padding_sum == 0",
+                    meta.query_advice(prev_padding_sum, Rotation::cur()),
+                );
+
+                cb.gate(meta.query_selector(q_enable))
+            });
+        }
+
+        meta.create_gate("boolean checks", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            //TODO: could be removed if combined with keccak circuit?
+            for data_bit in d_bits {
+                let b = meta.query_advice(data_bit, Rotation::cur());
+                cb.require_boolean("input data bit", b);
+            }
+
+            for s_flag in s_flags {
+                let s = meta.query_advice(s_flag, Rotation::cur());
+                cb.require_boolean("boolean state bit", s);
+            }
+
+            for i in 1..s_flags.len() {
+                let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                let s_i_sub1 = meta.query_advice(s_flags[i - 1], Rotation::cur());
+
+                cb.require_boolean("boolean state switch", s_i - s_i_sub1);
+            }
+
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        meta.create_gate("padding bit checks", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            for i in 1..s_flags.len() {
+                let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                let s_i_sub1 = meta.query_advice(s_flags[i - 1], Rotation::cur());
+                let d_bit_0 = meta.query_advice(d_bits[8 * i], Rotation::cur());
+                let s_padding_start = s_i - s_i_sub1;
+                cb.condition(s_padding_start, |cb| {
+                    cb.require_equal("start with 1", d_bit_0, 1u64.expr());
+                });
+            }
+
+            if is_last_row {
+                let s_last = meta.query_advice(s_flags[s_flags.len() - 1], Rotation::cur());
+                let d_last = meta.query_advice(d_bits[d_bits.len() - 1], Rotation::cur());
+
+                cb.condition(s_last, |cb| {
+                    cb.require_equal("end with 1", d_last, 1u64.expr())
+                });
+            }
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        if is_last_row {
+            meta.create_gate("sum padding check", |meta| {
+                let mut cb = BaseConstraintBuilder::new(5);
+
+                let prev_padding_sum = meta.query_advice(prev_padding_sum, Rotation::cur());
+
+                let mut sum_padding_bits = prev_padding_sum;
+                for i in 0..s_flags.len() {
+                    let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                    sum_padding_bits = d_bits[i * 8..(i + 1) * 8]
+                        .iter()
+                        .map(|b| meta.query_advice(*b, Rotation::cur()))
+                        .fold(sum_padding_bits, |sum, b| sum + s_i.clone() * b);
+                }
+
+                cb.require_equal("sum(padding_bits) == 2", sum_padding_bits, 2u64.expr());
+                cb.gate(meta.query_selector(q_enable))
+            });
+        } else {
+            meta.create_gate("sum padding", |meta| {
+                let mut cb = BaseConstraintBuilder::new(5);
+
+                let prev_padding_sum = meta.query_advice(prev_padding_sum, Rotation::cur());
+                let curr_padding_sum = meta.query_advice(curr_padding_sum, Rotation::cur());
+
+                let mut sum_padding_bits = prev_padding_sum;
+                for i in 0..s_flags.len() {
+                    let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                    sum_padding_bits = d_bits[i * 8..(i + 1) * 8]
+                        .iter()
+                        .map(|b| meta.query_advice(*b, Rotation::cur()))
+                        .fold(sum_padding_bits, |sum, b| sum + s_i.clone() * b);
+                }
+
+                cb.require_equal(
+                    "sum(padding_bits) == curr_padding_sum",
+                    sum_padding_bits,
+                    curr_padding_sum,
+                );
+                cb.gate(meta.query_selector(q_enable))
+            });
+        }
+
+        meta.create_gate("input len check", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            let len_0 = meta.query_advice(d_lens[0], Rotation::cur());
+            let prev_len = meta.query_advice(prev_len, Rotation::cur());
+            let s_0 = meta.query_advice(s_flags[0], Rotation::cur());
+
+            cb.require_equal("len[0] = prev_len + !s_0", len_0, prev_len + not::expr(s_0));
+
+            for i in 1..s_flags.len() {
+                let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                let len_i = meta.query_advice(d_lens[i], Rotation::cur());
+                let len_i_sub1 = meta.query_advice(d_lens[i - 1], Rotation::cur());
+                cb.require_equal(
+                    "len[i] = len[i-1] + !s_i",
+                    len_i,
+                    len_i_sub1 + not::expr(s_i),
+                );
+            }
+
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        meta.create_gate("input rlc check", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            let s_0 = meta.query_advice(s_flags[0], Rotation::cur());
+            let rlc_0 = meta.query_advice(d_rlcs[0], Rotation::cur());
+            let rlc_prev = meta.query_advice(prev_rlc, Rotation::cur());
+            let r = meta.query_advice(randomness, Rotation::cur());
+            let input_byte_0 = d_bits[0..8]
+                .iter()
+                .map(|bit| meta.query_advice(*bit, Rotation::cur()))
+                .fold(0u64.expr(), |v, b| v * 2u64.expr() + b);
+            cb.require_equal(
+                "rlc[i] = rlc[i-1]*r if s == 0 else rlc[i]",
+                rlc_0,
+                select::expr(s_0, rlc_prev.clone(), rlc_prev.clone() * r + input_byte_0),
+            );
+
+            for i in 1..s_flags.len() {
+                let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                let rlc_i = meta.query_advice(d_rlcs[i], Rotation::cur());
+                let rlc_i_sub1 = meta.query_advice(d_rlcs[i - 1], Rotation::cur());
+                let r = meta.query_advice(randomness, Rotation::cur());
+                let input_byte_i = d_bits[i * 8..(i + 1) * 8]
+                    .iter()
+                    .map(|bit| meta.query_advice(*bit, Rotation::cur()))
+                    .fold(0u64.expr(), |v, b| v * 2u64.expr() + b);
+                cb.require_equal(
+                    "rlc[i] = rlc[i-1]*r if s == 0 else rlc[i]",
+                    rlc_i,
+                    select::expr(
+                        s_i,
+                        rlc_i_sub1.clone(),
+                        rlc_i_sub1.clone() * r + input_byte_i,
+                    ),
+                );
+            }
+
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        if is_last_row {
+            meta.create_gate("input ending check", |meta| {
+                let mut cb = BaseConstraintBuilder::new(5);
+
+                let s_last = meta.query_advice(s_flags[s_flags.len() - 1], Rotation::cur());
+                let q_end = meta.query_advice(q_end, Rotation::cur());
+
+                cb.require_equal("s_last == q_end", s_last, q_end);
+                cb.gate(meta.query_selector(q_enable))
+            });
+        }
+
+        KeccakSubRowConfig {
+            q_enable,
+            q_end,
+            prev_len,
+            prev_rlc,
+            prev_s_flag,
+            prev_padding_sum,
+            curr_len,
+            curr_rlc,
+            curr_s_flag,
+            curr_padding_sum,
+            d_bits,
+            d_lens,
+            d_rlcs,
+            s_flags,
+
+            randomness,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns (last_len, last_rlc, last_s, randomness)
+    fn process(
+        &self,
+        mut layouter: &mut impl Layouter<F>,
+        prev_len: &AssignedCell<F, F>,
+        prev_rlc: &AssignedCell<F, F>,
+        prev_s_flag: &AssignedCell<F, F>,
+        prev_padding_sum: &AssignedCell<F, F>,
+        curr_sub_row: &KeccakPaddingSubRow<F>,
+        row_idx: u32,
+    ) -> Result<
+        (
+            AssignedCell<F, F>,
+            AssignedCell<F, F>,
+            AssignedCell<F, F>,
+            AssignedCell<F, F>,
+        ),
+        Error,
+    > {
+        // copy prev to current row
+        layouter.assign_region(
+            || format!("assign keccak sub row round {}", row_idx),
+            |mut region| {
+                self.set_row(
+                    &mut region,
+                    0,
+                    curr_sub_row.q_end,
+                    prev_len,
+                    prev_rlc,
+                    prev_s_flag,
+                    prev_padding_sum,
+                    curr_sub_row,
+                )
+            },
+        )
+    }
+
+    fn set_row(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        q_end: u64,
+        prev_len: &AssignedCell<F, F>,
+        prev_rlc: &AssignedCell<F, F>,
+        prev_s_flag: &AssignedCell<F, F>,
+        prev_padding_sum: &AssignedCell<F, F>,
+        curr_sub_row: &KeccakPaddingSubRow<F>,
+    ) -> Result<
+        (
+            AssignedCell<F, F>,
+            AssignedCell<F, F>,
+            AssignedCell<F, F>,
+            AssignedCell<F, F>,
+        ),
+        Error,
+    > {
+        let d_bits = curr_sub_row.d_bits;
+        let d_lens = curr_sub_row.d_lens;
+        let d_rlcs = curr_sub_row.d_rlcs;
+        let s_flags = curr_sub_row.s_flags;
+        let randomness = curr_sub_row.randomness;
+
+        self.q_enable.enable(region, offset)?;
+
+        // copy prev values
+        prev_len.copy_advice(|| "prev len", region, self.prev_len, offset)?;
+        prev_rlc.copy_advice(|| "prev rlc", region, self.prev_rlc, offset)?;
+        prev_s_flag.copy_advice(|| "prev s_flag", region, self.prev_s_flag, offset)?;
+        prev_padding_sum.copy_advice(
+            || "prev padding sum",
+            region,
+            self.prev_padding_sum,
+            offset,
+        )?;
+
+        // Input bits w/ padding
+        for (idx, (bit, column)) in d_bits.iter().zip(self.d_bits.iter()).enumerate() {
+            region.assign_advice(
+                || format!("assign input data bit {} {}", idx, offset),
+                *column,
+                offset,
+                || Ok(F::from(*bit as u64)),
+            )?;
+        }
+
+        for (idx, (s_flag, column)) in s_flags.iter().zip(self.s_flags.iter()).enumerate() {
+            region.assign_advice(
+                || format!("assign input data select flag {} {}", idx, offset),
+                *column,
+                offset,
+                || Ok(F::from(*s_flag as u64)),
+            )?;
+        }
+
+        for (idx, (d_len, column)) in d_lens.iter().zip(self.d_lens.iter()).enumerate() {
+            region.assign_advice(
+                || format!("assign input data len {} {}", idx, offset),
+                *column,
+                offset,
+                || Ok(F::from(*d_len as u64)),
+            )?;
+        }
+
+        for (idx, (d_rlc, column)) in d_rlcs.iter().zip(self.d_rlcs.iter()).enumerate() {
+            region.assign_advice(
+                || format!("assign input data rlc {} {}", idx, offset),
+                *column,
+                offset,
+                || Ok(*d_rlc),
+            )?;
+        }
+
+        region.assign_advice(
+            || format!("assign q_end{}", offset),
+            self.q_end,
+            offset,
+            || Ok(F::from(q_end)),
+        )?;
+
+        region.assign_advice(
+            || format!("assign randomness{}", offset),
+            self.randomness,
+            offset,
+            || Ok(randomness),
+        )?;
+
+        // output the curr len,rlc,s_flag & padding
+        let curr_len = region.assign_advice(
+            || format!("assign curr_len{}", offset),
+            self.curr_len,
+            offset,
+            || Ok(F::from(curr_sub_row.curr_len as u64)),
+        )?;
+
+        let curr_rlc = region.assign_advice(
+            || format!("assign curr_rlc{}", offset),
+            self.curr_rlc,
+            offset,
+            || Ok(curr_sub_row.curr_rlc),
+        )?;
+
+        let curr_s_flag = region.assign_advice(
+            || format!("assign curr_s_flag{}", offset),
+            self.curr_s_flag,
+            offset,
+            || Ok(F::from(curr_sub_row.curr_s_flag)),
+        )?;
+
+        let curr_padding_sum = region.assign_advice(
+            || format!("assign curr_padding_sum{}", offset),
+            self.curr_padding_sum,
+            offset,
+            || Ok(F::from(curr_sub_row.curr_padding_sum as u64)),
+        )?;
+
+        Ok((curr_len, curr_rlc, curr_s_flag, curr_padding_sum))
+    }
+}
+
+/// KeccakPaddingCircuit
+#[derive(Default)]
+pub struct KeccakMultiGadgetPaddingCircuit<F: Field> {
+    inputs: Vec<KeccakPaddingSubRow<F>>,
+    size: usize,
+    _marker: PhantomData<F>,
+}
+
+impl<F: Field> KeccakMultiGadgetPaddingCircuit<F> {
+    fn r() -> F {
+        F::from(123456)
+    }
+}
+
+impl<F: Field> Circuit<F> for KeccakMultiGadgetPaddingCircuit<F> {
+    type Config = KeccakMultiGadgetPaddingConfig<F>;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        KeccakMultiGadgetPaddingConfig::configure(meta)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        config.synthesize(
+            &mut layouter,
+            self.size,
+            &self.inputs,
+            KeccakMultiGadgetPaddingCircuit::r(),
+        )?;
+        Ok(())
+    }
+}
+
+impl<F: Field> KeccakMultiGadgetPaddingConfig<F> {
+    pub(crate) fn configure(meta: &mut ConstraintSystem<F>) -> Self {
+        let q_enable = meta.selector();
+        let first_row_config = KeccakSubRowConfig::configure(meta, true, false);
+        let middle_row_config = KeccakSubRowConfig::configure(meta, false, false);
+        let last_row_config = KeccakSubRowConfig::configure(meta, false, true);
+        let randomness = meta.advice_column();
+
+        KeccakMultiGadgetPaddingConfig {
+            q_enable,
+            first_row_config,
+            middle_row_config,
+            last_row_config,
+            randomness,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn synthesize(
+        &self,
+        mut layouter: &mut impl Layouter<F>,
+        _size: usize,
+        keccak_padding_row: &Vec<KeccakPaddingSubRow<F>>,
+        randomness: F,
+    ) -> Result<(), Error> {
+        assert_eq!(keccak_padding_row.len(), 17);
+
+        let mut prev_values = layouter.assign_region(
+            || "assign prev value of the first row",
+            |mut region| {
+                let offset = 0;
+                //TODO: rlc and len should be a input from previous circuit
+                let prev_len = region.assign_advice(
+                    || format!("assign prev_len{}", offset),
+                    self.first_row_config.prev_len,
+                    offset,
+                    || Ok(F::from(keccak_padding_row[0].prev_len as u64)),
+                )?;
+                let prev_rlc = region.assign_advice(
+                    || format!("assign prev_rlc{}", offset),
+                    self.first_row_config.prev_rlc,
+                    offset,
+                    || Ok(keccak_padding_row[0].prev_rlc),
+                )?;
+                let prev_s_flag = region.assign_advice(
+                    || format!("assign prev_s_flag{}", offset),
+                    self.first_row_config.prev_s_flag,
+                    offset,
+                    || Ok(F::zero()),
+                )?;
+                let prev_padding_sum = region.assign_advice(
+                    || format!("assign prev_padding_sum{}", offset),
+                    self.first_row_config.prev_padding_sum,
+                    offset,
+                    || Ok(F::zero()),
+                )?;
+                Ok((prev_len, prev_rlc, prev_s_flag, prev_padding_sum))
+            },
+        )?;
+
+        let mut prev_len = prev_values.0;
+        let mut prev_rlc = prev_values.1;
+        let mut prev_s_flag = prev_values.2;
+        let mut prev_padding_sum = prev_values.3;
+
+        prev_values = self.first_row_config.process(
+            layouter,
+            &prev_len,
+            &prev_rlc,
+            &prev_s_flag,
+            &prev_padding_sum,
+            &keccak_padding_row[0],
+            0,
+        )?;
+
+        prev_len = prev_values.0;
+        prev_rlc = prev_values.1;
+        prev_s_flag = prev_values.2;
+        prev_padding_sum = prev_values.3;
+
+        for i in 1..16 {
+            prev_values = self.middle_row_config.process(
+                layouter,
+                &prev_len,
+                &prev_rlc,
+                &prev_s_flag,
+                &prev_padding_sum,
+                &keccak_padding_row[i],
+                i as u32,
+            )?;
+
+            prev_len = prev_values.0;
+            prev_rlc = prev_values.1;
+            prev_s_flag = prev_values.2;
+            prev_padding_sum = prev_values.3;
+        }
+
+        self.last_row_config.process(
+            layouter,
+            &prev_len,
+            &prev_rlc,
+            &prev_s_flag,
+            &prev_padding_sum,
+            &keccak_padding_row[16],
+            16 as u32,
+        )?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::marker::PhantomData;
+
+    use crate::keccak_circuit::keccak_padding::KeccakPaddingRow;
+
+    use super::*;
+    use halo2_proofs::{dev::MockProver, pairing::bn256::Fr};
+
+    fn verify<F: Field>(k: u32, inputs: Vec<KeccakPaddingSubRow<F>>, success: bool) {
+        let circuit = KeccakMultiGadgetPaddingCircuit::<F> {
+            inputs,
+            size: 2usize.pow(k),
+            _marker: PhantomData,
+        };
+
+        let prover = MockProver::<F>::run(k, &circuit, vec![]).unwrap();
+        let err = prover.verify();
+        let print_failures = true;
+        if err.is_err() && print_failures {
+            for e in err.err().iter() {
+                for s in e.iter() {
+                    println!("{}", s);
+                }
+            }
+        }
+        let err = prover.verify();
+        assert_eq!(err.is_ok(), success);
+    }
+
+    fn generate_padding_sub_rows<F: Field>(data_len: u32) -> Vec<KeccakPaddingSubRow<F>> {
+        let mut keccak_padding = KeccakPaddingRow::<F> {
+            d_bits: [0; KECCAK_WIDTH],
+            d_lens: [0; KECCAK_RATE_IN_BYTES],
+            d_rlcs: [F::from(0u64); KECCAK_RATE_IN_BYTES],
+            s_flags: [false; KECCAK_RATE_IN_BYTES],
+            q_end: 1u64,
+        };
+
+        let data_len_offset = data_len % KECCAK_RATE_IN_BYTES as u32;
+        let data_len_base = (data_len / KECCAK_RATE_IN_BYTES as u32) * KECCAK_RATE_IN_BYTES as u32;
+
+        keccak_padding.s_flags[0] = data_len_offset == 0u32;
+        keccak_padding.d_lens[0] = data_len_base + !keccak_padding.s_flags[0] as u32;
+
+        for i in 1 as usize..KECCAK_RATE_IN_BYTES {
+            keccak_padding.s_flags[i] = {
+                if (i as u32) < data_len_offset {
+                    false
+                } else {
+                    true
+                }
+            };
+            keccak_padding.d_lens[i] =
+                keccak_padding.d_lens[i - 1] + !keccak_padding.s_flags[i] as u32;
+        }
+
+        for i in data_len_offset as usize..KECCAK_RATE {
+            keccak_padding.d_bits[i] = 0u8;
+        }
+        keccak_padding.d_bits[data_len_offset as usize * 8] = 1;
+        keccak_padding.d_bits[KECCAK_RATE - 1] = 1;
+
+        println!("{:?}", keccak_padding.s_flags);
+        println!("{:?}", keccak_padding.d_bits);
+        println!("{:?}", keccak_padding.d_lens);
+
+        let mut out = Vec::<KeccakPaddingSubRow<F>>::new();
+        let mut curr_len = data_len_base;
+        let mut curr_rlc = F::zero();
+        let mut curr_s_flag = false;
+        let mut curr_padding_sum = 0;
+        let randomness = KeccakMultiGadgetPaddingCircuit::r();
+
+        for i in 0..KECCAK_RATE / 64 {
+            let prev_len = curr_len;
+            let prev_rlc = curr_rlc;
+            let prev_s_flag = curr_s_flag;
+            let prev_padding_sum = curr_padding_sum;
+
+            curr_len = keccak_padding.s_flags[i * 8..(i + 1) * 8]
+                .iter()
+                .fold(prev_len, |sum, v| sum + (!v as u32));
+            curr_rlc = keccak_padding.d_bits[i * 64..(i + 1) * 64]
+                .chunks(8)
+                .map(|bits| bits.iter().fold(0, |byte, bit| byte * 2 + bit))
+                .zip(keccak_padding.s_flags[i * 8..(i + 1) * 8].iter())
+                .fold(prev_rlc, |rlc, (byte, flag)| {
+                    rlc * randomness + F::from(byte as u64 * (!flag as u64))
+                });
+            curr_s_flag = keccak_padding.s_flags[(i + 1) * 8 - 1];
+            curr_padding_sum = keccak_padding.d_bits[i * 64..(i + 1) * 64]
+                .iter()
+                .enumerate()
+                .fold(prev_padding_sum, |sum, (idx, v)| {
+                    println!(
+                        "{} + {} * {}",
+                        sum,
+                        *v,
+                        keccak_padding.s_flags[i * 8 + idx / 8]
+                    );
+                    sum + (*v as u32) * (keccak_padding.s_flags[i * 8 + idx / 8] as u32)
+                });
+            println!("{}", curr_padding_sum);
+            assert!(curr_padding_sum <= 2);
+
+            let sub_row = KeccakPaddingSubRow::<F> {
+                q_end: 1u64,
+                prev_len,
+                prev_rlc,
+                prev_s_flag,
+                prev_padding_sum,
+                curr_len: curr_len,
+                curr_rlc: curr_rlc,
+                curr_s_flag: curr_s_flag,
+                curr_padding_sum: curr_padding_sum,
+                randomness: randomness,
+                d_bits: keccak_padding.d_bits[i * 64..(i + 1) * 64]
+                    .try_into()
+                    .unwrap(),
+                d_lens: keccak_padding.d_lens[i * 8..(i + 1) * 8]
+                    .try_into()
+                    .unwrap(),
+                d_rlcs: keccak_padding.d_rlcs[i * 8..(i + 1) * 8]
+                    .try_into()
+                    .unwrap(),
+                s_flags: keccak_padding.s_flags[i * 8..(i + 1) * 8]
+                    .try_into()
+                    .unwrap(),
+            };
+            out.push(sub_row);
+        }
+
+        out
+    }
+
+    static K: u32 = 8;
+
+    #[test]
+    fn bit_keccak_len_0() {
+        let input = generate_padding_sub_rows::<Fr>(0);
+        verify::<Fr>(K, input, true);
+    }
+
+    #[test]
+    fn bit_keccak_len_1() {
+        let input = generate_padding_sub_rows::<Fr>(1);
+        verify::<Fr>(K, input, true);
+    }
+
+    #[test]
+    fn bit_keccak_len_2() {
+        let input = generate_padding_sub_rows::<Fr>(2);
+        verify::<Fr>(K, input, true);
+    }
+
+    #[test]
+    fn bit_keccak_len_135() {
+        let input = generate_padding_sub_rows::<Fr>(135);
+        verify::<Fr>(K, input, true);
+    }
+
+    #[test]
+    fn bit_keccak_len_300() {
+        let input = generate_padding_sub_rows::<Fr>(300);
+        verify::<Fr>(K, input, true);
+    }
+
+    #[test]
+    fn bit_keccak_invalid_padding_begin() {
+        // first bit is 0
+        let mut input = generate_padding_sub_rows::<Fr>(11);
+        input[1].d_bits[11 * 8 % 64] = 0u8;
+        verify::<Fr>(K, input, false);
+    }
+
+    #[test]
+    fn bit_keccak_invalid_padding_end() {
+        // last bit is 0
+        let mut input = generate_padding_sub_rows::<Fr>(73);
+        let row_idx = (KECCAK_RATE - 1) / 64;
+        let bit_idx = (KECCAK_RATE - 1) % 64;
+        input[row_idx].d_bits[bit_idx] = 0u8;
+        verify::<Fr>(K, input, false);
+    }
+
+    #[test]
+    fn bit_keccak_invalid_padding_mid() {
+        // some 1 in padding
+        let mut input = generate_padding_sub_rows::<Fr>(123);
+        let row_idx = (KECCAK_RATE - 2) / 64;
+        let bit_idx = (KECCAK_RATE - 2) % 64;
+        input[row_idx].d_bits[bit_idx] = 1u8;
+        verify::<Fr>(K, input, false);
+    }
+
+    #[test]
+    fn bit_keccak_invalid_input_len() {
+        // wrong len
+        let mut input = generate_padding_sub_rows::<Fr>(123);
+        let row_idx = 124 / 8;
+        let bit_idx = 124 % 8;
+        input[row_idx].d_lens[bit_idx] = 124;
+        verify::<Fr>(K, input, false);
+    }
+}

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding_multi_gadgets.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding_multi_gadgets.rs
@@ -55,17 +55,17 @@ pub struct KeccakMultiGadgetPaddingConfig<F> {
 
 pub(crate) struct KeccakPaddingSubRow<F: Field> {
     pub(crate) q_end: u64,
-    prev_len: u32,
+    prev_len: u64,
     prev_rlc: F,
     prev_s_flag: bool,
     prev_padding_sum: u32,
-    curr_len: u32,
+    curr_len: u64,
     curr_rlc: F,
     curr_s_flag: bool,
     curr_padding_sum: u32,
     randomness: F,
     pub(crate) d_bits: [u8; KECCAK_DATA_REGION_WIDTH],
-    pub(crate) d_lens: [u32; KECCAK_DATA_REGION_WIDTH / 8],
+    pub(crate) d_lens: [u64; KECCAK_DATA_REGION_WIDTH / 8],
     pub(crate) d_rlcs: [F; KECCAK_DATA_REGION_WIDTH / 8],
     pub(crate) s_flags: [bool; KECCAK_DATA_REGION_WIDTH / 8],
 }
@@ -546,7 +546,7 @@ impl<F: Field> KeccakMultiGadgetPaddingCircuit<F> {
         F::from(123456)
     }
 
-    fn generate_padding_sub_rows(data_len: u32) -> Vec<KeccakPaddingSubRow<F>> {
+    fn generate_padding_sub_rows(data_len: u64) -> Vec<KeccakPaddingSubRow<F>> {
         let keccak_padding = KeccakPaddingRow::generate_padding(data_len);
 
         let mut out = Vec::<KeccakPaddingSubRow<F>>::new();
@@ -564,7 +564,7 @@ impl<F: Field> KeccakMultiGadgetPaddingCircuit<F> {
 
             curr_len = keccak_padding.s_flags[i * 8..(i + 1) * 8]
                 .iter()
-                .fold(prev_len, |sum, v| sum + (!v as u32));
+                .fold(prev_len, |sum, v| sum + (!v as u64));
             curr_rlc = keccak_padding.d_bits[i * 64..(i + 1) * 64]
                 .chunks(8)
                 .map(|bits| bits.iter().rev().fold(0, |byte, bit| byte * 2 + bit))
@@ -841,7 +841,7 @@ mod tests {
         assert_eq!(err.is_ok(), success);
     }
 
-    fn generate_padding_sub_rows<F: Field>(data_len: u32) -> Vec<KeccakPaddingSubRow<F>> {
+    fn generate_padding_sub_rows<F: Field>(data_len: u64) -> Vec<KeccakPaddingSubRow<F>> {
         KeccakMultiGadgetPaddingCircuit::generate_padding_sub_rows(data_len)
     }
 

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding_multi_gadgets.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding_multi_gadgets.rs
@@ -155,14 +155,13 @@ impl<F: Field> KeccakSubRowConfig<F> {
 
             let s_0 = meta.query_advice(s_flags[0], Rotation::cur());
             let s_prev = meta.query_advice(prev_s_flag, Rotation::cur());
-
-            cb.require_boolean("boolean state switch", s_0 - s_prev);
+            cb.require_boolean("boolean state switch from prev row", s_0 - s_prev);
 
             for i in 1..s_flags.len() {
                 let s_i = meta.query_advice(s_flags[i], Rotation::cur());
                 let s_i_sub1 = meta.query_advice(s_flags[i - 1], Rotation::cur());
 
-                cb.require_boolean("boolean state switch", s_i - s_i_sub1);
+                cb.require_boolean("boolean state switch inside row", s_i - s_i_sub1);
             }
 
             cb.gate(meta.query_selector(q_enable))
@@ -176,7 +175,11 @@ impl<F: Field> KeccakSubRowConfig<F> {
             let d_bit_0 = meta.query_advice(d_bits[0], Rotation::cur());
             let s_padding_start = s_0 - s_prev;
             cb.condition(s_padding_start, |cb| {
-                cb.require_equal("start with 1", d_bit_0, 1u64.expr());
+                cb.require_equal(
+                    "start with 1 if the padding start from pos 0",
+                    d_bit_0,
+                    1u64.expr(),
+                );
             });
 
             for i in 1..s_flags.len() {
@@ -185,7 +188,7 @@ impl<F: Field> KeccakSubRowConfig<F> {
                 let d_bit_0 = meta.query_advice(d_bits[8 * i], Rotation::cur());
                 let s_padding_start = s_i - s_i_sub1;
                 cb.condition(s_padding_start, |cb| {
-                    cb.require_equal("start with 1", d_bit_0, 1u64.expr());
+                    cb.require_equal("start with 1 inside row", d_bit_0, 1u64.expr());
                 });
             }
 

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows.rs
@@ -121,8 +121,6 @@ impl<F: Field> KeccakMultiRowPaddingConfig<F> {
                 let s_i = s_flag_column_builder.query_advice(meta, i);
                 let s_i_sub1 = s_flag_column_builder.query_advice(meta, i - 1);
                 let d_bit_0 = data_column_builder.query_advice(meta, 8 * i);
-                // constraints.push(("begin with 1", (s_i - s_i_sub1) * (d_bit_0 -
-                // 1u64.expr())));
                 let s_padding_start = s_i - s_i_sub1;
                 cb.condition(s_padding_start, |cb| {
                     cb.require_equal("start with 1", d_bit_0, 1u64.expr());
@@ -260,45 +258,31 @@ impl<F: Field> KeccakMultiRowPaddingConfig<F> {
 
         // Input bits w/ padding
         for (idx, bit) in d_bits.iter().enumerate() {
-            let (col, rot) = self.d_bits_builder.relative_advice_coordinate(idx as u32);
-            region.assign_advice(
-                || format!("assign input data bit {} {}", idx, offset),
-                col,
-                (offset as i32 + rot.0) as usize,
-                || Ok(F::from(*bit as u64)),
-            )?;
+            self.d_bits_builder
+                .assign_advice(region, idx, offset as i32, F::from(*bit as u64))?;
         }
 
         for (idx, s_flag) in s_flags.iter().enumerate() {
-            let (col, rot) = self.s_flags_builder.relative_advice_coordinate(idx as u32);
-
-            region.assign_advice(
-                || format!("assign input data select flag {} {}", idx, offset),
-                col,
-                (offset as i32 + rot.0) as usize,
-                || Ok(F::from(*s_flag as u64)),
+            self.s_flags_builder.assign_advice(
+                region,
+                idx,
+                offset as i32,
+                F::from(*s_flag as u64),
             )?;
         }
 
         for (idx, d_len) in d_lens.iter().enumerate() {
-            let (col, rot) = self.d_lens_builder.relative_advice_coordinate(idx as u32);
-
-            region.assign_advice(
-                || format!("assign input data len {} {}", idx, offset),
-                col,
-                (offset as i32 + rot.0) as usize,
-                || Ok(F::from(*d_len as u64)),
+            self.d_lens_builder.assign_advice(
+                region,
+                idx,
+                offset as i32,
+                F::from(*d_len as u64),
             )?;
         }
 
         for (idx, d_rlc) in d_rlcs.iter().enumerate() {
-            let (col, rot) = self.d_rlcs_builder.relative_advice_coordinate(idx as u32);
-            region.assign_advice(
-                || format!("assign input data rlc {} {}", idx, offset),
-                col,
-                (offset as i32 + rot.0) as usize,
-                || Ok(*d_rlc),
-            )?;
+            self.d_rlcs_builder
+                .assign_advice(region, idx, offset as i32, *d_rlc)?;
         }
 
         region.assign_advice(

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows.rs
@@ -29,12 +29,21 @@ pub struct KeccakMultiRowPaddingConfig<F> {
     _marker: PhantomData<F>,
 }
 
-/// KeccakPaddingCircuit
-#[derive(Default)]
+/// KeccakMultiRowPaddingCircuit
 pub struct KeccakMultiRowPaddingCircuit<F: Field> {
     inputs: Vec<KeccakPaddingRow<F>>,
     size: usize,
     _marker: PhantomData<F>,
+}
+
+impl<F: Field> Default for KeccakMultiRowPaddingCircuit<F> {
+    fn default() -> Self {
+        KeccakMultiRowPaddingCircuit::<F> {
+            inputs: vec![KeccakPaddingRow::generate_padding(0)],
+            size: 2usize.pow(4),
+            _marker: PhantomData,
+        }
+    }
 }
 
 impl<F: Field> KeccakMultiRowPaddingCircuit<F> {

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows.rs
@@ -37,19 +37,19 @@ pub(crate) struct KeccakPaddingRow<F: Field> {
 
 /// KeccakPaddingCircuit
 #[derive(Default)]
-pub struct KeccakPaddingCircuit<F: Field> {
+pub struct KeccakMultiRowPaddingCircuit<F: Field> {
     inputs: Vec<KeccakPaddingRow<F>>,
     size: usize,
     _marker: PhantomData<F>,
 }
 
-impl<F: Field> KeccakPaddingCircuit<F> {
+impl<F: Field> KeccakMultiRowPaddingCircuit<F> {
     fn r() -> F {
         F::from(123456)
     }
 }
 
-impl<F: Field> Circuit<F> for KeccakPaddingCircuit<F> {
+impl<F: Field> Circuit<F> for KeccakMultiRowPaddingCircuit<F> {
     type Config = KeccakMultiRowPaddingConfig<F>;
     type FloorPlanner = SimpleFloorPlanner;
 
@@ -70,7 +70,7 @@ impl<F: Field> Circuit<F> for KeccakPaddingCircuit<F> {
             layouter,
             self.size,
             &self.inputs[0],
-            KeccakPaddingCircuit::r(),
+            KeccakMultiRowPaddingCircuit::r(),
         )?;
         Ok(())
     }
@@ -311,7 +311,7 @@ mod tests {
     use halo2_proofs::{dev::MockProver, pairing::bn256::Fr};
 
     fn verify<F: Field>(k: u32, inputs: Vec<KeccakPaddingRow<F>>, success: bool) {
-        let circuit = KeccakPaddingCircuit::<F> {
+        let circuit = KeccakMultiRowPaddingCircuit::<F> {
             inputs,
             size: 2usize.pow(k),
             _marker: PhantomData,

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows.rs
@@ -61,11 +61,7 @@ impl<F: Field> Circuit<F> for KeccakMultiRowPaddingCircuit<F> {
         KeccakMultiRowPaddingConfig::configure(meta)
     }
 
-    fn synthesize(
-        &self,
-        config: Self::Config,
-        mut layouter: impl Layouter<F>,
-    ) -> Result<(), Error> {
+    fn synthesize(&self, config: Self::Config, layouter: impl Layouter<F>) -> Result<(), Error> {
         config.assign(
             layouter,
             self.size,

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows.rs
@@ -249,7 +249,7 @@ impl<F: Field> KeccakMultiRowPaddingConfig<F> {
         offset: usize,
         q_end: u64,
         d_bits: [u8; KECCAK_WIDTH],
-        d_lens: [u32; KECCAK_RATE_IN_BYTES],
+        d_lens: [u64; KECCAK_RATE_IN_BYTES],
         d_rlcs: [F; KECCAK_RATE_IN_BYTES],
         s_flags: [bool; KECCAK_RATE_IN_BYTES],
         randomness: F,

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows_2.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows_2.rs
@@ -24,7 +24,7 @@ pub struct KeccakPaddingConfig<F> {
     q_enable: Selector,
     q_first: Selector,
     q_last: Selector,
-    q_end: Column<Advice>,
+    // q_end: Column<Advice>,
     curr_padding_sum: Column<Advice>,
     d_bits: [Column<Advice>; KECCAK_REGION_WIDTH],
     d_lens: [Column<Advice>; KECCAK_REGION_WIDTH / 8],
@@ -260,7 +260,7 @@ impl<F: Field> KeccakPaddingConfig<F> {
         allocated_d_bits: Option<[Column<Advice>; KECCAK_REGION_WIDTH]>,
     ) -> Self {
         let q_enable = meta.selector();
-        let q_end = meta.advice_column();
+        // let q_end = meta.advice_column();
         let q_first = meta.selector();
         let q_last = meta.selector();
         let curr_padding_sum = meta.advice_column();
@@ -470,20 +470,20 @@ impl<F: Field> KeccakPaddingConfig<F> {
             cb.gate(meta.query_selector(q_enable))
         });
 
-        meta.create_gate("last row input ending check", |meta| {
-            let mut cb = BaseConstraintBuilder::new(5);
+        // meta.create_gate("last row input ending check", |meta| {
+        //     let mut cb = BaseConstraintBuilder::new(5);
 
-            let s_last = meta.query_advice(s_flags[s_flags.len() - 1], Rotation::cur());
-            let q_end = meta.query_advice(q_end, Rotation::cur());
-            cb.require_equal("s_last == q_end", s_last, q_end);
-            cb.gate(meta.query_selector(q_last))
-        });
+        //     let s_last = meta.query_advice(s_flags[s_flags.len() - 1],
+        // Rotation::cur());     let q_end = meta.query_advice(q_end,
+        // Rotation::cur());     cb.require_equal("s_last == q_end", s_last,
+        // q_end);     cb.gate(meta.query_selector(q_last))
+        // });
 
         KeccakPaddingConfig {
             q_enable,
             q_first,
             q_last,
-            q_end,
+            // q_end,
             curr_padding_sum,
             d_bits,
             d_lens,
@@ -632,12 +632,12 @@ impl<F: Field> KeccakPaddingConfig<F> {
                 || Ok(F::from(randomness)),
             )?;
 
-            region.assign_advice(
-                || format!("assign q_end{}", offset),
-                self.q_end,
-                enabled_region_offset,
-                || Ok(F::from(data_block.q_end)),
-            )?;
+            // region.assign_advice(
+            //     || format!("assign q_end{}", offset),
+            //     self.q_end,
+            //     enabled_region_offset,
+            //     || Ok(F::from(data_block.q_end)),
+            // )?;
         }
 
         Ok(())

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows_2.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows_2.rs
@@ -1,0 +1,671 @@
+use crate::{evm_circuit::util::constraint_builder::BaseConstraintBuilder, util::Expr};
+use eth_types::Field;
+use gadgets::util::{not, select};
+use halo2_proofs::{
+    circuit::{Layouter, Region, SimpleFloorPlanner},
+    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Fixed, Selector},
+    poly::Rotation,
+};
+use std::marker::PhantomData;
+
+const KECCAK_REGION_WIDTH: usize = 64;
+const KECCAK_REGION_WIDTH_IN_BYTES: usize = KECCAK_REGION_WIDTH / 8;
+const KECCAK_REGION_HEIGHT: u64 = 17;
+const KECCAK_RATE: usize = 1088;
+const KECCAK_RATE_IN_BYTES: usize = KECCAK_RATE / 8;
+
+/// KeccakPaddingConfig
+#[derive(Clone, Debug)]
+pub struct KeccakPaddingConfig<F> {
+    q_enable: Selector,
+    q_end: Column<Advice>,
+    is_first_row: Column<Fixed>,
+    is_last_row: Column<Fixed>,
+    curr_len: Column<Advice>,
+    curr_rlc: Column<Advice>,
+    curr_s_flag: Column<Advice>,
+    curr_padding_sum: Column<Advice>,
+    d_bits: [Column<Advice>; KECCAK_REGION_WIDTH],
+    d_lens: [Column<Advice>; KECCAK_REGION_WIDTH / 8],
+    d_rlcs: [Column<Advice>; KECCAK_REGION_WIDTH / 8],
+    s_flags: [Column<Advice>; KECCAK_REGION_WIDTH / 8],
+    randomness: Column<Advice>,
+
+    _marker: PhantomData<F>,
+}
+
+#[derive(Debug)]
+pub(crate) struct KeccakPaddingBlock<F: Field> {
+    pub(crate) q_end: u64,
+    pub(crate) acc_rlc: F,
+    pub(crate) acc_len: u32,
+    pub(crate) block_rows: [KeccakPaddingBlockRow<F>; KECCAK_REGION_HEIGHT as usize],
+}
+
+#[derive(Debug)]
+pub(crate) struct KeccakPaddingBlockRow<F: Field> {
+    pub(crate) curr_len: u32,
+    pub(crate) curr_rlc: F,
+    pub(crate) curr_s_flag: bool,
+    pub(crate) curr_padding_sum: u32,
+    pub(crate) d_bits: [u8; KECCAK_REGION_WIDTH],
+    pub(crate) d_lens: [u32; KECCAK_REGION_WIDTH_IN_BYTES],
+    pub(crate) d_rlcs: [F; KECCAK_REGION_WIDTH_IN_BYTES],
+    pub(crate) s_flags: [bool; KECCAK_REGION_WIDTH_IN_BYTES],
+}
+
+/// KeccakPaddingCircuit
+#[derive(Default)]
+pub struct KeccakPaddingCircuit<F: Field> {
+    inputs: Vec<KeccakPaddingBlock<F>>,
+    size: usize,
+    _marker: PhantomData<F>,
+}
+
+impl<F: Field> KeccakPaddingCircuit<F> {
+    fn r() -> F {
+        F::from(123456)
+    }
+}
+
+impl<F: Field> Circuit<F> for KeccakPaddingCircuit<F> {
+    type Config = KeccakPaddingConfig<F>;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        KeccakPaddingConfig::configure(meta)
+    }
+
+    fn synthesize(&self, config: Self::Config, layouter: impl Layouter<F>) -> Result<(), Error> {
+        config.assign(
+            layouter,
+            self.size,
+            &self.inputs[0],
+            KeccakPaddingCircuit::r(),
+        )?;
+        Ok(())
+    }
+}
+
+impl<F: Field> KeccakPaddingConfig<F> {
+    pub(crate) fn configure(meta: &mut ConstraintSystem<F>) -> Self {
+        let q_enable = meta.selector();
+        let q_end = meta.advice_column();
+        let is_first_row = meta.fixed_column();
+        let is_last_row = meta.fixed_column();
+        let curr_len = meta.advice_column();
+        let curr_rlc = meta.advice_column();
+        let curr_s_flag = meta.advice_column();
+        let curr_padding_sum = meta.advice_column();
+        let d_bits = [(); KECCAK_REGION_WIDTH].map(|_| meta.advice_column());
+        let d_lens = [(); KECCAK_REGION_WIDTH / 8].map(|_| meta.advice_column());
+        let d_rlcs = [(); KECCAK_REGION_WIDTH / 8].map(|_| meta.advice_column());
+        let s_flags = [(); KECCAK_REGION_WIDTH / 8].map(|_| meta.advice_column());
+        let randomness = meta.advice_column();
+
+        meta.create_gate("prev should be 0 for the 1st row", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            // len & rlc are passed down by previous circuit, they are not necessarily 0.
+            let is_first = meta.query_fixed(is_first_row, Rotation::cur());
+
+            cb.condition(is_first.clone(), |cb| {
+                cb.require_zero(
+                    "prev_s_flag == 0",
+                    meta.query_advice(curr_s_flag, Rotation::prev()),
+                );
+            });
+            cb.condition(is_first.clone(), |cb| {
+                cb.require_zero(
+                    "prev_padding_sum == 0",
+                    meta.query_advice(curr_padding_sum, Rotation::prev()),
+                );
+            });
+
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        meta.create_gate("boolean checks", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            //TODO: could be removed if combined with keccak circuit?
+            for data_bit in d_bits {
+                let b = meta.query_advice(data_bit, Rotation::cur());
+                cb.require_boolean("input data bit", b);
+            }
+
+            for s_flag in s_flags {
+                let s = meta.query_advice(s_flag, Rotation::cur());
+                cb.require_boolean("boolean state bit", s);
+            }
+
+            for i in 1..s_flags.len() {
+                let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                let s_i_sub1 = meta.query_advice(s_flags[i - 1], Rotation::cur());
+
+                cb.require_boolean("boolean state switch", s_i - s_i_sub1);
+            }
+
+            let is_first = meta.query_fixed(is_first_row, Rotation::cur());
+            cb.require_boolean("boolean first flag", is_first);
+
+            let is_last = meta.query_fixed(is_last_row, Rotation::cur());
+            cb.require_boolean("boolean first flag", is_last);
+
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        meta.create_gate("start/end padding bit check", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            let s_0 = meta.query_advice(s_flags[0], Rotation::cur());
+            let s_prev = meta.query_advice(curr_s_flag, Rotation::prev());
+            let d_bit_0 = meta.query_advice(d_bits[0], Rotation::cur());
+            let s_padding_start = s_0 - s_prev;
+            cb.condition(s_padding_start, |cb| {
+                cb.require_equal(
+                    "start with 1 if the padding start from pos 0",
+                    d_bit_0,
+                    1u64.expr(),
+                );
+            });
+
+            for i in 1..s_flags.len() {
+                let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                let s_i_sub1 = meta.query_advice(s_flags[i - 1], Rotation::cur());
+                let d_bit_0 = meta.query_advice(d_bits[8 * i], Rotation::cur());
+                let s_padding_start = s_i - s_i_sub1;
+                cb.condition(s_padding_start, |cb| {
+                    cb.require_equal("start with 1 inside row", d_bit_0, 1u64.expr());
+                });
+            }
+
+            let is_last = meta.query_fixed(is_last_row, Rotation::cur());
+            let s_last = meta.query_advice(s_flags[s_flags.len() - 1], Rotation::cur());
+            let d_last = meta.query_advice(d_bits[d_bits.len() - 1], Rotation::cur());
+
+            let s_padding_end = s_last * is_last;
+            cb.condition(s_padding_end, |cb| {
+                cb.require_equal("end with 1", d_last, 1u64.expr())
+            });
+
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        meta.create_gate("sum padding", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            let prev_padding_sum = meta.query_advice(curr_padding_sum, Rotation::prev());
+            let curr_padding_sum = meta.query_advice(curr_padding_sum, Rotation::cur());
+
+            let mut sum_padding_bits = prev_padding_sum;
+            for i in 0..s_flags.len() {
+                let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                sum_padding_bits = d_bits[i * 8..(i + 1) * 8]
+                    .iter()
+                    .map(|b| meta.query_advice(*b, Rotation::cur()))
+                    .fold(sum_padding_bits, |sum, b| sum + s_i.clone() * b);
+            }
+
+            let last_row = meta.query_fixed(is_last_row, Rotation::cur());
+            cb.require_equal(
+                "sum(padding_bits) == curr_padding_sum",
+                sum_padding_bits,
+                curr_padding_sum.clone(),
+            );
+            cb.condition(last_row, |cb| {
+                cb.require_equal(
+                    "sum(padding_bits) == 2",
+                    2u64.expr(),
+                    curr_padding_sum.clone(),
+                )
+            });
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        meta.create_gate("input len check", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            let prev_len = meta.query_advice(curr_len, Rotation::prev());
+            let len_0 = meta.query_advice(d_lens[0], Rotation::cur());
+            let s_0 = meta.query_advice(s_flags[0], Rotation::cur());
+
+            cb.require_equal("len[0] = prev_len + !s_0", len_0, prev_len + not::expr(s_0));
+
+            for i in 1..s_flags.len() {
+                let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                let len_i = meta.query_advice(d_lens[i], Rotation::cur());
+                let len_i_sub1 = meta.query_advice(d_lens[i - 1], Rotation::cur());
+                cb.require_equal(
+                    "len[i] = len[i-1] + !s_i",
+                    len_i,
+                    len_i_sub1 + not::expr(s_i),
+                );
+            }
+
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        meta.create_gate("input rlc check", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            let r = meta.query_advice(randomness, Rotation::cur());
+            cb.require_equal(
+                "using same randomness",
+                meta.query_advice(randomness, Rotation::prev()),
+                r.clone(),
+            );
+
+            let s_0 = meta.query_advice(s_flags[0], Rotation::cur());
+            let rlc_0 = meta.query_advice(d_rlcs[0], Rotation::cur());
+            let rlc_prev = meta.query_advice(curr_rlc, Rotation::prev());
+            let input_byte_0 = d_bits[0..8]
+                .iter()
+                .map(|bit| meta.query_advice(*bit, Rotation::cur()))
+                .fold(0u64.expr(), |v, b| v * 2u64.expr() + b);
+            cb.require_equal(
+                "rlc[0] = prev_rlc*r + byte[0] if s == 0 else rlc_prev",
+                rlc_0,
+                select::expr(
+                    s_0,
+                    rlc_prev.clone(),
+                    rlc_prev.clone() * r.clone() + input_byte_0,
+                ),
+            );
+
+            for i in 1..s_flags.len() {
+                let s_i = meta.query_advice(s_flags[i], Rotation::cur());
+                let rlc_i = meta.query_advice(d_rlcs[i], Rotation::cur());
+                let rlc_i_sub1 = meta.query_advice(d_rlcs[i - 1], Rotation::cur());
+                let r = meta.query_advice(randomness, Rotation::cur());
+                let input_byte_i = d_bits[i * 8..(i + 1) * 8]
+                    .iter()
+                    .map(|bit| meta.query_advice(*bit, Rotation::cur()))
+                    .fold(0u64.expr(), |v, b| v * 2u64.expr() + b);
+                cb.require_equal(
+                    "rlc[i] = rlc[i-1]*r if s == 0 else rlc[i]",
+                    rlc_i,
+                    select::expr(
+                        s_i,
+                        rlc_i_sub1.clone(),
+                        rlc_i_sub1.clone() * r + input_byte_i,
+                    ),
+                );
+            }
+
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        meta.create_gate("input ending check", |meta| {
+            let mut cb = BaseConstraintBuilder::new(5);
+
+            let s_last = meta.query_advice(s_flags[s_flags.len() - 1], Rotation::cur());
+            let q_end = meta.query_advice(q_end, Rotation::cur());
+
+            let last_row = meta.query_fixed(is_last_row, Rotation::cur());
+            cb.condition(last_row, |cb| {
+                cb.require_equal("s_last == q_end", s_last, q_end);
+            });
+            cb.gate(meta.query_selector(q_enable))
+        });
+
+        KeccakPaddingConfig {
+            q_enable,
+            q_end,
+            is_first_row,
+            is_last_row,
+            curr_len,
+            curr_rlc,
+            curr_s_flag,
+            curr_padding_sum,
+            d_bits,
+            d_lens,
+            d_rlcs,
+            s_flags,
+            randomness,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn assign(
+        &self,
+        mut layouter: impl Layouter<F>,
+        _size: usize,
+        keccak_padding_block: &KeccakPaddingBlock<F>,
+        randomness: F,
+    ) -> Result<(), Error> {
+        layouter.assign_region(
+            || "assign keccak rounds",
+            |mut region| {
+                self.set_region(&mut region, 0, keccak_padding_block, randomness)?;
+                Ok(())
+            },
+        )
+    }
+
+    fn set_region(
+        &self,
+        region: &mut Region<'_, F>,
+        offset: usize,
+        data_block: &KeccakPaddingBlock<F>,
+        randomness: F,
+    ) -> Result<(), Error> {
+        let enabled_region_offset = offset + 1;
+        self.q_enable.enable(region, enabled_region_offset)?;
+
+        // setup 0 row, the prev of the enabled region
+        region.assign_advice(
+            || format!("assign curr_len{}", offset),
+            self.curr_len,
+            offset,
+            || Ok(F::from(data_block.acc_len as u64)),
+        )?;
+
+        region.assign_advice(
+            || format!("assign curr_rlc{}", offset),
+            self.curr_rlc,
+            offset,
+            || Ok(data_block.acc_rlc),
+        )?;
+
+        region.assign_advice(
+            || format!("assign curr_s_flag{}", offset),
+            self.curr_s_flag,
+            offset,
+            || Ok(F::zero()),
+        )?;
+        region.assign_advice(
+            || format!("assign curr_padding_sum{}", offset),
+            self.curr_padding_sum,
+            offset,
+            || Ok(F::zero()),
+        )?;
+        region.assign_advice(
+            || format!("assign randomness{}", offset),
+            self.randomness,
+            offset,
+            || Ok(F::from(randomness)),
+        )?;
+
+        //then the row setup loop
+        for i in 0..KECCAK_REGION_HEIGHT as usize {
+            // Input bits w/ padding
+            let row_data = &data_block.block_rows[i];
+            let d_bits = row_data.d_bits;
+            let d_lens = row_data.d_lens;
+            let d_rlcs = row_data.d_rlcs;
+            let s_flags = row_data.s_flags;
+
+            for (idx, (bit, column)) in d_bits.iter().zip(self.d_bits.iter()).enumerate() {
+                region.assign_advice(
+                    || format!("assign input data bit {} {}", idx, offset),
+                    *column,
+                    enabled_region_offset + i,
+                    || Ok(F::from(*bit as u64)),
+                )?;
+            }
+
+            for (idx, (s_flag, column)) in s_flags.iter().zip(self.s_flags.iter()).enumerate() {
+                region.assign_advice(
+                    || format!("assign input data select flag {} {}", idx, offset),
+                    *column,
+                    enabled_region_offset + i,
+                    || Ok(F::from(*s_flag as u64)),
+                )?;
+            }
+
+            for (idx, (d_len, column)) in d_lens.iter().zip(self.d_lens.iter()).enumerate() {
+                region.assign_advice(
+                    || format!("assign input data len {} {}", idx, offset),
+                    *column,
+                    enabled_region_offset + i,
+                    || Ok(F::from(*d_len as u64)),
+                )?;
+            }
+
+            for (idx, (d_rlc, column)) in d_rlcs.iter().zip(self.d_rlcs.iter()).enumerate() {
+                region.assign_advice(
+                    || format!("assign input data rlc {} {}", idx, offset),
+                    *column,
+                    enabled_region_offset + i,
+                    || Ok(*d_rlc),
+                )?;
+            }
+
+            region.assign_fixed(
+                || format!("assign fixed first flag {}", offset),
+                self.is_first_row,
+                enabled_region_offset + i,
+                || Ok(F::from((i == 0) as u64)),
+            )?;
+
+            region.assign_fixed(
+                || format!("assign fixed first flag {}", offset),
+                self.is_last_row,
+                enabled_region_offset + i,
+                || Ok(F::from((i + 1 == KECCAK_REGION_HEIGHT as usize) as u64)),
+            )?;
+
+            // output the curr len,rlc,s_flag & padding
+            region.assign_advice(
+                || format!("assign curr_len{}", offset),
+                self.curr_len,
+                enabled_region_offset + i,
+                || Ok(F::from(row_data.curr_len as u64)),
+            )?;
+
+            region.assign_advice(
+                || format!("assign curr_rlc{}", offset),
+                self.curr_rlc,
+                enabled_region_offset + i,
+                || Ok(row_data.curr_rlc),
+            )?;
+
+            region.assign_advice(
+                || format!("assign curr_s_flag{}", offset),
+                self.curr_s_flag,
+                enabled_region_offset + i,
+                || Ok(F::from(row_data.curr_s_flag)),
+            )?;
+            region.assign_advice(
+                || format!("assign curr_padding_sum{}", offset),
+                self.curr_padding_sum,
+                enabled_region_offset + i,
+                || Ok(F::from(row_data.curr_padding_sum as u64)),
+            )?;
+
+            region.assign_advice(
+                || format!("assign randomness{}", offset),
+                self.randomness,
+                enabled_region_offset + i,
+                || Ok(F::from(randomness)),
+            )?;
+
+            region.assign_advice(
+                || format!("assign q_end{}", offset),
+                self.q_end,
+                enabled_region_offset + i,
+                || Ok(F::from(data_block.q_end)),
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::marker::PhantomData;
+
+    use crate::keccak_circuit::keccak_padding::tests::generate_padding;
+    use crate::keccak_circuit::keccak_padding::KeccakPaddingRow;
+
+    use super::*;
+    use halo2_proofs::{dev::MockProver, pairing::bn256::Fr};
+
+    fn verify<F: Field>(k: u32, input: KeccakPaddingBlock<F>, success: bool) {
+        let circuit = KeccakPaddingCircuit::<F> {
+            inputs: vec![input],
+            size: 2usize.pow(k),
+            _marker: PhantomData,
+        };
+
+        let prover = MockProver::<F>::run(k, &circuit, vec![]).unwrap();
+        let err = prover.verify();
+        let print_failures = true;
+        if err.is_err() && print_failures {
+            for e in err.err().iter() {
+                for s in e.iter() {
+                    println!("{}", s);
+                }
+            }
+        }
+        let err = prover.verify();
+        assert_eq!(err.is_ok(), success);
+    }
+
+    fn from_full_padding_block<F: Field>(
+        keccak_padding_full_row: &KeccakPaddingRow<F>,
+    ) -> KeccakPaddingBlock<F> {
+        let mut rows = Vec::<KeccakPaddingBlockRow<F>>::new();
+        let mut curr_len = keccak_padding_full_row.acc_len;
+        let mut curr_rlc = keccak_padding_full_row.acc_rlc;
+        let mut curr_padding_sum = 0;
+        let mut curr_s_flag: bool;
+
+        for i in 0..KECCAK_REGION_HEIGHT as usize {
+            let prev_padding_sum = curr_padding_sum;
+
+            curr_len =
+                keccak_padding_full_row.d_lens[(i + 1) * KECCAK_REGION_WIDTH_IN_BYTES as usize - 1];
+            println!("{:?}", curr_len);
+
+            curr_rlc =
+                keccak_padding_full_row.d_rlcs[(i + 1) * KECCAK_REGION_WIDTH_IN_BYTES as usize - 1];
+            println!("{:?}", curr_rlc);
+
+            curr_s_flag = keccak_padding_full_row.s_flags
+                [(i + 1) * KECCAK_REGION_WIDTH_IN_BYTES as usize - 1];
+            curr_padding_sum = keccak_padding_full_row.d_bits[i * 64..(i + 1) * 64]
+                .iter()
+                .enumerate()
+                .fold(prev_padding_sum, |sum, (idx, v)| {
+                    // println!(
+                    //     "{} + {} * {}",
+                    //     sum,
+                    //     *v,
+                    //     keccak_padding.s_flags[i * 8 + idx / 8]
+                    // );
+                    sum + (*v as u32) * (keccak_padding_full_row.s_flags[i * 8 + idx / 8] as u32)
+                });
+            println!("{}", curr_padding_sum);
+            // assert!(curr_padding_sum <= 2);
+
+            let sub_row = KeccakPaddingBlockRow::<F> {
+                curr_len: curr_len,
+                curr_rlc: curr_rlc,
+                curr_s_flag: curr_s_flag,
+                curr_padding_sum: curr_padding_sum,
+                d_bits: keccak_padding_full_row.d_bits[i * 64..(i + 1) * 64]
+                    .try_into()
+                    .unwrap(),
+                d_lens: keccak_padding_full_row.d_lens[i * 8..(i + 1) * 8]
+                    .try_into()
+                    .unwrap(),
+                d_rlcs: keccak_padding_full_row.d_rlcs[i * 8..(i + 1) * 8]
+                    .try_into()
+                    .unwrap(),
+                s_flags: keccak_padding_full_row.s_flags[i * 8..(i + 1) * 8]
+                    .try_into()
+                    .unwrap(),
+            };
+            rows.push(sub_row);
+        }
+
+        KeccakPaddingBlock::<F> {
+            q_end: 1u64,
+            acc_len: keccak_padding_full_row.acc_len,
+            acc_rlc: keccak_padding_full_row.acc_rlc,
+            block_rows: rows.try_into().unwrap(),
+        }
+    }
+
+    static K: u32 = 8;
+
+    #[test]
+    fn bit_keccak_len_0() {
+        let full_data = generate_padding::<Fr>(0);
+        let input = from_full_padding_block(&full_data);
+        verify::<Fr>(K, input, true);
+    }
+
+    #[test]
+    fn bit_keccak_len_1() {
+        let full_data = generate_padding::<Fr>(1);
+        let input = from_full_padding_block(&full_data);
+        verify::<Fr>(K, input, true);
+    }
+
+    #[test]
+    fn bit_keccak_len_2() {
+        let full_data = generate_padding::<Fr>(2);
+        let input = from_full_padding_block(&full_data);
+        verify::<Fr>(K, input, true);
+    }
+
+    #[test]
+    fn bit_keccak_len_135() {
+        let full_data = generate_padding::<Fr>(135);
+        let input = from_full_padding_block(&full_data);
+
+        verify::<Fr>(K, input, true);
+    }
+
+    #[test]
+    fn bit_keccak_len_300() {
+        let full_data = generate_padding::<Fr>(300);
+        let input = from_full_padding_block(&full_data);
+
+        verify::<Fr>(K, input, true);
+    }
+
+    #[test]
+    fn bit_keccak_invalid_padding_begin() {
+        // first bit is 0
+        let mut full_data = generate_padding::<Fr>(11);
+        full_data.d_bits[11 * 8] = 0u8;
+        let input = from_full_padding_block(&full_data);
+        verify::<Fr>(K, input, false);
+    }
+
+    #[test]
+    fn bit_keccak_invalid_padding_end() {
+        // last bit is 0
+        let mut full_data = generate_padding::<Fr>(73);
+        full_data.d_bits[KECCAK_RATE - 1] = 0u8;
+        let input = from_full_padding_block(&full_data);
+        verify::<Fr>(K, input, false);
+    }
+
+    #[test]
+    fn bit_keccak_invalid_padding_mid() {
+        // some 1 in padding
+        let mut full_data = generate_padding::<Fr>(123);
+        full_data.d_bits[KECCAK_RATE - 2] = 1u8;
+        let input = from_full_padding_block(&full_data);
+        verify::<Fr>(K, input, false);
+    }
+
+    #[test]
+    fn bit_keccak_invalid_input_len() {
+        // wrong len
+        let mut full_data = generate_padding::<Fr>(123);
+        full_data.d_lens[124] = 124;
+        let input = from_full_padding_block(&full_data);
+        verify::<Fr>(K, input, false);
+    }
+}

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows_2.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows_2.rs
@@ -136,9 +136,9 @@ impl<F: Field> KeccakPaddingConfig<F> {
 
             for i in 1..s_flags.len() {
                 let s_i = meta.query_advice(s_flags[i], Rotation::cur());
-                let s_i_sub1 = meta.query_advice(s_flags[i - 1], Rotation::cur());
+                let s_i_prev = meta.query_advice(s_flags[i - 1], Rotation::cur());
 
-                cb.require_boolean("boolean state switch", s_i - s_i_sub1);
+                cb.require_boolean("boolean state switch", s_i - s_i_prev);
             }
 
             let is_first = meta.query_fixed(is_first_row, Rotation::cur());
@@ -154,10 +154,10 @@ impl<F: Field> KeccakPaddingConfig<F> {
             let mut cb = BaseConstraintBuilder::new(5);
 
             let s_0 = meta.query_advice(s_flags[0], Rotation::cur());
-            let s_prev =
+            let s_0_prev =
                 meta.query_advice(s_flags[KECCAK_REGION_WIDTH_IN_BYTES - 1], Rotation::prev());
             let d_bit_0 = meta.query_advice(d_bits[0], Rotation::cur());
-            let s_padding_start = s_0 - s_prev;
+            let s_padding_start = s_0 - s_0_prev;
             cb.condition(s_padding_start, |cb| {
                 cb.require_equal(
                     "start with 1 if the padding start from pos 0",
@@ -168,9 +168,9 @@ impl<F: Field> KeccakPaddingConfig<F> {
 
             for i in 1..s_flags.len() {
                 let s_i = meta.query_advice(s_flags[i], Rotation::cur());
-                let s_i_sub1 = meta.query_advice(s_flags[i - 1], Rotation::cur());
+                let s_i_prev = meta.query_advice(s_flags[i - 1], Rotation::cur());
                 let d_bit_0 = meta.query_advice(d_bits[8 * i], Rotation::cur());
-                let s_padding_start = s_i - s_i_sub1;
+                let s_padding_start = s_i - s_i_prev;
                 cb.condition(s_padding_start, |cb| {
                     cb.require_equal("start with 1 inside row", d_bit_0, 1u64.expr());
                 });
@@ -222,21 +222,25 @@ impl<F: Field> KeccakPaddingConfig<F> {
         meta.create_gate("input len check", |meta| {
             let mut cb = BaseConstraintBuilder::new(5);
 
-            let prev_len =
+            let len_0_prev =
                 meta.query_advice(d_lens[KECCAK_REGION_WIDTH_IN_BYTES - 1], Rotation::prev());
             let len_0 = meta.query_advice(d_lens[0], Rotation::cur());
             let s_0 = meta.query_advice(s_flags[0], Rotation::cur());
 
-            cb.require_equal("len[0] = prev_len + !s_0", len_0, prev_len + not::expr(s_0));
+            cb.require_equal(
+                "len[0] = prev_len + !s_0",
+                len_0,
+                len_0_prev + not::expr(s_0),
+            );
 
             for i in 1..s_flags.len() {
                 let s_i = meta.query_advice(s_flags[i], Rotation::cur());
                 let len_i = meta.query_advice(d_lens[i], Rotation::cur());
-                let len_i_sub1 = meta.query_advice(d_lens[i - 1], Rotation::cur());
+                let len_i_prev = meta.query_advice(d_lens[i - 1], Rotation::cur());
                 cb.require_equal(
                     "len[i] = len[i-1] + !s_i",
                     len_i,
-                    len_i_sub1 + not::expr(s_i),
+                    len_i_prev + not::expr(s_i),
                 );
             }
 
@@ -255,7 +259,7 @@ impl<F: Field> KeccakPaddingConfig<F> {
 
             let s_0 = meta.query_advice(s_flags[0], Rotation::cur());
             let rlc_0 = meta.query_advice(d_rlcs[0], Rotation::cur());
-            let rlc_prev =
+            let rlc_0_prev =
                 meta.query_advice(d_rlcs[KECCAK_REGION_WIDTH_IN_BYTES - 1], Rotation::prev());
             let input_byte_0 = d_bits[0..8]
                 .iter()
@@ -266,15 +270,15 @@ impl<F: Field> KeccakPaddingConfig<F> {
                 rlc_0,
                 select::expr(
                     s_0,
-                    rlc_prev.clone(),
-                    rlc_prev.clone() * r.clone() + input_byte_0,
+                    rlc_0_prev.clone(),
+                    rlc_0_prev.clone() * r.clone() + input_byte_0,
                 ),
             );
 
             for i in 1..s_flags.len() {
                 let s_i = meta.query_advice(s_flags[i], Rotation::cur());
                 let rlc_i = meta.query_advice(d_rlcs[i], Rotation::cur());
-                let rlc_i_sub1 = meta.query_advice(d_rlcs[i - 1], Rotation::cur());
+                let rlc_i_prev = meta.query_advice(d_rlcs[i - 1], Rotation::cur());
                 let r = meta.query_advice(randomness, Rotation::cur());
                 let input_byte_i = d_bits[i * 8..(i + 1) * 8]
                     .iter()
@@ -286,8 +290,8 @@ impl<F: Field> KeccakPaddingConfig<F> {
                     rlc_i,
                     select::expr(
                         s_i,
-                        rlc_i_sub1.clone(),
-                        rlc_i_sub1.clone() * r + input_byte_i,
+                        rlc_i_prev.clone(),
+                        rlc_i_prev.clone() * r + input_byte_i,
                     ),
                 );
             }

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows_2.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows_2.rs
@@ -278,6 +278,7 @@ impl<F: Field> KeccakPaddingConfig<F> {
                 let r = meta.query_advice(randomness, Rotation::cur());
                 let input_byte_i = d_bits[i * 8..(i + 1) * 8]
                     .iter()
+                    .rev()
                     .map(|bit| meta.query_advice(*bit, Rotation::cur()))
                     .fold(0u64.expr(), |v, b| v * 2u64.expr() + b);
                 cb.require_equal(

--- a/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows_2.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_padding_multirows_2.rs
@@ -240,7 +240,7 @@ impl<F: Field> Circuit<F> for KeccakPaddingMultiRowsExCircuit<F> {
     }
 
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
-        KeccakPaddingConfig::configure(meta)
+        KeccakPaddingConfig::configure(meta, None)
     }
 
     fn synthesize(&self, config: Self::Config, layouter: impl Layouter<F>) -> Result<(), Error> {
@@ -255,13 +255,19 @@ impl<F: Field> Circuit<F> for KeccakPaddingMultiRowsExCircuit<F> {
 }
 
 impl<F: Field> KeccakPaddingConfig<F> {
-    pub(crate) fn configure(meta: &mut ConstraintSystem<F>) -> Self {
+    pub(crate) fn configure(
+        meta: &mut ConstraintSystem<F>,
+        allocated_d_bits: Option<[Column<Advice>; KECCAK_REGION_WIDTH]>,
+    ) -> Self {
         let q_enable = meta.selector();
         let q_end = meta.advice_column();
         let q_first = meta.selector();
         let q_last = meta.selector();
         let curr_padding_sum = meta.advice_column();
-        let d_bits = [(); KECCAK_REGION_WIDTH].map(|_| meta.advice_column());
+        let d_bits = allocated_d_bits.map_or_else(
+            || [(); KECCAK_REGION_WIDTH].map(|_| meta.advice_column()),
+            |d_bits| d_bits,
+        );
         let d_lens = [(); KECCAK_REGION_WIDTH_IN_BYTES].map(|_| meta.advice_column());
         let d_rlcs = [(); KECCAK_REGION_WIDTH_IN_BYTES].map(|_| meta.advice_column());
         let s_flags = [(); KECCAK_REGION_WIDTH_IN_BYTES].map(|_| meta.advice_column());

--- a/zkevm-circuits/src/keccak_circuit/keccak_utils.rs
+++ b/zkevm-circuits/src/keccak_circuit/keccak_utils.rs
@@ -1,0 +1,128 @@
+use eth_types::Field;
+use halo2_proofs::{
+    plonk::{Advice, Column, ConstraintSystem, Expression, VirtualCells},
+    poly::Rotation,
+};
+
+/// BaseAdviceColumnBuilder
+#[derive(Clone, Debug)]
+pub struct BaseAdviceColumnBuilderConfig {
+    pub(crate) data_size: u32,
+    pub(crate) start_point: (i32, i32),
+    pub(crate) advices: Vec<Column<Advice>>,
+}
+
+impl BaseAdviceColumnBuilderConfig {
+    fn new(advices: Vec<Column<Advice>>, data_size: u32, start_point: (i32, i32)) -> Self {
+        BaseAdviceColumnBuilderConfig {
+            data_size,
+            start_point: start_point,
+            advices: advices,
+        }
+    }
+
+    fn query_advice_coordinates(&self, input_idx: u32) -> (Column<Advice>, Rotation) {
+        let region_width = self.advices.len() as u32;
+        let column_idx = (input_idx % region_width) as usize;
+        let rotation_idx = (input_idx / region_width) as i32 + 1 - self.start_point.1;
+        (self.advices[column_idx], Rotation(rotation_idx))
+    }
+}
+
+/// BaseAdviceColumnBuilder
+#[derive(Clone, Debug)]
+pub struct BaseAdviceColumnBuilder {
+    pub(crate) config: BaseAdviceColumnBuilderConfig,
+}
+
+impl BaseAdviceColumnBuilder {
+    /// configuire()
+    pub fn configure<F: Field>(
+        meta: &mut ConstraintSystem<F>,
+        data_size: u32,
+        region_width: u32,
+        start_point: (i32, i32),
+    ) -> Self {
+        //TODO: x offset not supported now.
+        assert_eq!(start_point.0, 0);
+
+        let advices = (0..region_width)
+            .into_iter()
+            .map(|_| meta.advice_column())
+            .collect();
+
+        BaseAdviceColumnBuilder {
+            config: BaseAdviceColumnBuilderConfig::new(advices, data_size, start_point),
+        }
+    }
+
+    /// query_advice
+    pub fn query_advice<F: Field>(
+        &self,
+        meta: &mut VirtualCells<'_, F>,
+        input_idx: u32,
+    ) -> Expression<F> {
+        let config = &self.config;
+        let (col, rot) = config.query_advice_coordinates(input_idx);
+        meta.query_advice(col, rot)
+    }
+
+    /// show (column, rotation) of the index-ed advice cell
+    pub fn relative_advice_coordinate(&self, input_idx: u32) -> (Column<Advice>, Rotation) {
+        let config = &self.config;
+        config.query_advice_coordinates(input_idx)
+    }
+
+    /// return size of the managed data
+    pub fn size(&self) -> u32 {
+        self.config.data_size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use halo2_proofs::pairing::bn256::Fr;
+
+    #[test]
+    fn configure_works() {
+        let cs = &mut ConstraintSystem::<Fr>::default();
+        let advice_builder = BaseAdviceColumnBuilder::configure(cs, 100, 100, (0, 0));
+        assert_eq!(advice_builder.config.data_size, 100);
+        assert_eq!(advice_builder.config.advices.len(), 100);
+    }
+
+    #[test]
+    fn query_works() {
+        let cs = &mut ConstraintSystem::<Fr>::default();
+        let advice_builder = BaseAdviceColumnBuilder::configure(cs, 500, 100, (0, 0));
+        let (col, rot) = advice_builder.config.query_advice_coordinates(0);
+        assert_eq!(col, advice_builder.config.advices[0]);
+        assert_eq!(rot, Rotation(0));
+
+        let (col, rot) = advice_builder.config.query_advice_coordinates(101);
+        assert_eq!(col, advice_builder.config.advices[1]);
+        assert_eq!(rot, Rotation(1));
+
+        let (col, rot) = advice_builder.config.query_advice_coordinates(305);
+        assert_eq!(col, advice_builder.config.advices[5]);
+        assert_eq!(rot, Rotation(3));
+    }
+
+    #[test]
+    fn query_works_non_zero_offset() {
+        let cs = &mut ConstraintSystem::<Fr>::default();
+        let advice_builder = BaseAdviceColumnBuilder::configure(cs, 500, 100, (0, 3));
+        let (col, rot) = advice_builder.config.query_advice_coordinates(0);
+        assert_eq!(col, advice_builder.config.advices[0]);
+        assert_eq!(rot, Rotation(-2));
+
+        let (col, rot) = advice_builder.config.query_advice_coordinates(101);
+        assert_eq!(col, advice_builder.config.advices[1]);
+        assert_eq!(rot, Rotation(-1));
+
+        let (col, rot) = advice_builder.config.query_advice_coordinates(305);
+        assert_eq!(col, advice_builder.config.advices[5]);
+        assert_eq!(rot, Rotation(1));
+    }
+}


### PR DESCRIPTION
Implement padding following the spec:
```
[s]     0        0        1        1        1
[d]     01001111 01101010 10000000 00000000 00000001
[len]   1        2        2        2        2
[rlc]   ...

rlc(data) keccak(data) len(data)

- require_boolean(s[i])
- require_boolean(s[i] - s[i-1])
- (s[i] - s[i-1]) * require_equal(d[8*i + 0], 1)
- s[last] * require_equal(d[last], 1)
- s[i] * not(s[i]-s[i-1]) * not::expr(s[last]) * require_equal(d[i], 0)
  -> selectors change a bit for which bit position in the byte we're checking, middle bits are always 0
- require_equal(len[i-1] + not(s[i]), len[i])
- require_equal(rlc[i], select(s[i], rlc[i], rlc[i-1]*r + d[i*8..(i+1)*8))
- require_equal(s[last], q_end)
```
What have done:
1. A circuit to check if padding has the correct pattern, i.e., 10{7, 1086}1
2. Few unit test cases

The impl pattern might be naive because unfamiliar with the whole brunch of the theories and related APIs.

Some issues:
1. All constraints in spec are manually transformed, for example `s[last] * require_equal(d[last], 1)` in spec ==> `s_last * (d_last - 1.expr()))` in code. Will see if existing specific set of APIs could express them better. 
2. Use `sum(s[i] * padding_bits) == 2` instead of `s[i] * not(s[i]-s[i-1]) * not::expr(s[last]) * require_equal(d[i], 0)`. Any difference??
3. The rlc(input) is not checked so far, learning the way to calculate rlc in circuit.
4. Not work together with keccak circuit. This one is an independent circuit. Would its logic be better to be merged into keccak circuit?
